### PR TITLE
Remove unused IrExpression overloads in IrBuilder.kt

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/utils/IrBuilder.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/utils/IrBuilder.kt
@@ -1,39 +1,12 @@
 package com.github.kitakkun.aspectk.compiler.backend.utils
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrBlockBuilder
 import org.jetbrains.kotlin.ir.builders.Scope
 import org.jetbrains.kotlin.ir.declarations.IrSymbolOwner
-import org.jetbrains.kotlin.ir.expressions.IrExpression
-import org.jetbrains.kotlin.ir.types.impl.IrErrorClassImpl.symbol
 
 fun IrSymbolOwner.irBlockBuilder(pluginContext: IrPluginContext) =
     IrBlockBuilder(
-        context = pluginContext,
-        scope = Scope(symbol),
-        startOffset = startOffset,
-        endOffset = endOffset,
-    )
-
-fun IrSymbolOwner.irBlockBodyBuilder(pluginContext: IrPluginContext) =
-    IrBlockBodyBuilder(
-        context = pluginContext,
-        scope = Scope(symbol),
-        startOffset = startOffset,
-        endOffset = endOffset,
-    )
-
-fun IrExpression.irBlockBuilder(pluginContext: IrPluginContext) =
-    IrBlockBuilder(
-        context = pluginContext,
-        scope = Scope(symbol),
-        startOffset = startOffset,
-        endOffset = endOffset,
-    )
-
-fun IrExpression.irBlockBodyBuilder(pluginContext: IrPluginContext) =
-    IrBlockBodyBuilder(
         context = pluginContext,
         scope = Scope(symbol),
         startOffset = startOffset,


### PR DESCRIPTION
## Summary

- `IrExpression.irBlockBuilder` / `irBlockBodyBuilder` compiled only because of a stale `IrErrorClassImpl.symbol` import — calling either would have built a `Scope` against an error-class symbol.
- Verified via grep that no call site references the broken overloads, then deleted them along with the bad import and the unused `IrSymbolOwner.irBlockBodyBuilder`.

## Test plan

- [x] `./gradlew :aspectk-compiler:compileKotlin` passes
- [x] Surviving `IrSymbolOwner.irBlockBuilder` call sites (`ApplyAdviceTransformer`, `AfterAdviceFunctionTransformer`) still compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)