### PR TITLE
Validate advice function signature at FIR time

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AdviceSignatureChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AdviceSignatureChecker.kt
@@ -1,0 +1,61 @@
+package com.github.kitakkun.aspectk.compiler.fir.checker
+
+import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import com.github.kitakkun.aspectk.compiler.AspectKConsts
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirFunctionChecker
+import org.jetbrains.kotlin.fir.declarations.FirFunction
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.types.classId
+import org.jetbrains.kotlin.fir.types.coneType
+
+class AdviceSignatureChecker : FirFunctionChecker() {
+    override fun check(
+        declaration: FirFunction,
+        context: CheckerContext,
+        reporter: DiagnosticReporter,
+    ) {
+        with(context) {
+            val adviceAnnotationShortName = adviceAnnotationShortName(declaration) ?: return
+
+            val params = declaration.valueParameters
+            when {
+                params.isEmpty() -> Unit
+
+                params.size == 1 -> {
+                    val paramType = params.single().returnTypeRef.coneType
+                    if (paramType.classId != AspectKConsts.JOIN_POINT_CLASS_ID) {
+                        reporter.reportOn(
+                            declaration.source,
+                            AspectKErrors.ADVICE_INVALID_SIGNATURE,
+                            "@$adviceAnnotationShortName advice must take either no parameters or a single ${AspectKConsts.JOIN_POINT_CLASS_ID.shortClassName.asString()} parameter",
+                        )
+                    }
+                }
+
+                else -> {
+                    reporter.reportOn(
+                        declaration.source,
+                        AspectKErrors.ADVICE_INVALID_SIGNATURE,
+                        "@$adviceAnnotationShortName advice must take either no parameters or a single ${AspectKConsts.JOIN_POINT_CLASS_ID.shortClassName.asString()} parameter (got ${params.size} parameters)",
+                    )
+                }
+            }
+        }
+    }
+
+    context(CheckerContext)
+    private fun adviceAnnotationShortName(declaration: FirFunction): String? {
+        return when {
+            declaration.hasAnnotation(AspectKAnnotations.BEFORE_CLASS_ID, session) ->
+                AspectKAnnotations.BEFORE_CLASS_ID.shortClassName.asString()
+            declaration.hasAnnotation(AspectKAnnotations.AFTER_CLASS_ID, session) ->
+                AspectKAnnotations.AFTER_CLASS_ID.shortClassName.asString()
+            declaration.hasAnnotation(AspectKAnnotations.AROUND_CLASS_ID, session) ->
+                AspectKAnnotations.AROUND_CLASS_ID.shortClassName.asString()
+            else -> null
+        }
+    }
+}

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKDiagnosticRendererFactory.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKDiagnosticRendererFactory.kt
@@ -28,5 +28,10 @@ object AspectKDiagnosticRendererFactory : BaseDiagnosticRendererFactory() {
             message = "Invalid pointcut expression: {0}",
             rendererA = TO_STRING,
         )
+        put(
+            factory = AspectKErrors.ADVICE_INVALID_SIGNATURE,
+            message = "{0}",
+            rendererA = TO_STRING,
+        )
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
@@ -13,6 +13,7 @@ object AspectKErrors {
     val EMPTY_POINTCUT_EXPRESSION by warning0<KtFunction>()
     val ASPECT_CLASS_WITH_NO_POINTCUT_OR_ADVICE_ENTRIES by warning0<KtClass>()
     val INVALID_POINTCUT_EXPRESSION by error1<KtFunction, String>()
+    val ADVICE_INVALID_SIGNATURE by error1<KtFunction, String>()
 
     init {
         RootDiagnosticRendererFactory.registerFactory(AspectKDiagnosticRendererFactory)

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKFirCheckerExtension.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKFirCheckerExtension.kt
@@ -8,7 +8,10 @@ import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtensi
 
 class AspectKFirCheckerExtension(session: FirSession) : FirAdditionalCheckersExtension(session) {
     override val declarationCheckers = object : DeclarationCheckers() {
-        override val functionCheckers: Set<FirFunctionChecker> = setOf(AdviceOrPointcutFunctionChecker())
+        override val functionCheckers: Set<FirFunctionChecker> = setOf(
+            AdviceOrPointcutFunctionChecker(),
+            AdviceSignatureChecker(),
+        )
         override val classCheckers: Set<FirClassChecker> = setOf(AspectClassChecker())
     }
 }


### PR DESCRIPTION
## Summary

Add `AdviceSignatureChecker` (FIR `FirFunctionChecker`) that errors when a `@Before` / `@After` / `@Around` advice function takes anything other than zero parameters or a single `JoinPoint` parameter. Previously the IR transformer would silently call the advice without arguments, leaving extra params unbound at runtime — now misuse is caught at compile time.

## What gets accepted vs rejected

**OK (zero parameters):**
```kotlin
@Aspect
class MyAspect {
    @Before("execution(public com/example/Foo.bar())")
    fun before() {                          // accepted
        println("before bar")
    }
}
```

**OK (single `JoinPoint` parameter):**
```kotlin
@Aspect
class MyAspect {
    @After("execution(public com/example/Foo.*())")
    fun after(jp: JoinPoint) {              // accepted
        println("called ${jp.methodName}")
    }
}
```

**Rejected — wrong parameter type:**
```kotlin
@Aspect
class MyAspect {
    @Before("args(String)")
    fun before(text: String) {              // <-- ERROR
        println("called with $text")
    }
}
```
```
e: MyAspect.kt:4:5: @Before advice must take either no parameters
   or a single JoinPoint parameter
```
(Even though the pointcut matches `(String)`, AspectK never binds the argument back to the advice parameter — `text` would have been unbound at runtime.)

**Rejected — too many parameters:**
```kotlin
@Aspect
class MyAspect {
    @After("args(Int, String)")
    fun after(n: Int, s: String) {          // <-- ERROR
        ...
    }
}
```
```
e: MyAspect.kt:4:5: @After advice must take either no parameters
   or a single JoinPoint parameter (got 2 parameters)
```

## Why this matters

Without the checker, the offending code compiles but produces IR that calls `aspect.before()` (no arguments) — the `text` / `n` / `s` parameters would be passed as default/zero values or trigger a runtime crash depending on the JVM call site. Surfacing this at compile time is much friendlier than chasing a `NullPointerException` from inside generated code.

## Follow-up

Once `@Around` is migrated to `ProceedingJoinPoint` (PR #11), this checker should also accept that type for `@Around` advice. Currently it only allows `JoinPoint`.

## Test plan

- [x] `./gradlew :aspectk-compiler:compileKotlin` passes
- [x] Manually verify by temporarily adding a bad signature to `test/.../LogAspect.kt` and confirming the diagnostic appears
