### PR TITLE
Resolve named() pointcut references at FIR time

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AdviceOrPointcutFunctionChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AdviceOrPointcutFunctionChecker.kt
@@ -1,6 +1,7 @@
 package com.github.kitakkun.aspectk.compiler.fir.checker
 
 import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import com.github.kitakkun.aspectk.expression.PointcutExpression
 import com.github.kitakkun.aspectk.expression.expressionparser.PointcutExpressionParser
 import com.github.kitakkun.aspectk.expression.lexer.AspectKLexer
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
@@ -12,6 +13,11 @@ import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
 import org.jetbrains.kotlin.fir.declarations.getStringArgument
 import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
 
 class AdviceOrPointcutFunctionChecker : FirFunctionChecker() {
     override fun check(
@@ -111,11 +117,75 @@ class AdviceOrPointcutFunctionChecker : FirFunctionChecker() {
             return
         }
 
-        try {
+        val parsed = try {
             val tokens = AspectKLexer(pointcutExpression).analyze()
             PointcutExpressionParser(tokens).expression()
         } catch (e: Throwable) {
             reporter.reportOn(declaration.source, AspectKErrors.INVALID_POINTCUT_EXPRESSION, e.message ?: "Unknown error")
+            return
         }
+
+        verifyNamedPointcutReferences(parsed, declaration, reporter)
+    }
+
+    context(CheckerContext)
+    private fun verifyNamedPointcutReferences(
+        expression: PointcutExpression,
+        declaration: FirFunction,
+        reporter: DiagnosticReporter,
+    ) {
+        collectNamedReferences(expression).forEach { named ->
+            val classId = namedReferenceClassId(named)
+            val classSymbol = session.symbolProvider.getClassLikeSymbolByClassId(classId) as? FirRegularClassSymbol
+            if (classSymbol == null) {
+                reporter.reportOn(
+                    declaration.source,
+                    AspectKErrors.NAMED_POINTCUT_CLASS_NOT_FOUND,
+                    classId.asFqNameString(),
+                )
+                return@forEach
+            }
+
+            val targetName = named.functionName.name
+            val pointcutFn = classSymbol.declarationSymbols
+                .filterIsInstance<FirNamedFunctionSymbol>()
+                .firstOrNull {
+                    it.name.asString() == targetName &&
+                        it.hasAnnotation(AspectKAnnotations.POINTCUT_CLASS_ID, session)
+                }
+            if (pointcutFn == null) {
+                reporter.reportOn(
+                    declaration.source,
+                    AspectKErrors.NAMED_POINTCUT_FUNCTION_NOT_FOUND,
+                    "${classId.asFqNameString()}.$targetName",
+                )
+            }
+        }
+    }
+
+    private fun collectNamedReferences(expression: PointcutExpression): List<PointcutExpression.Named> {
+        val out = mutableListOf<PointcutExpression.Named>()
+        fun walk(e: PointcutExpression) {
+            when (e) {
+                is PointcutExpression.Named -> out.add(e)
+                is PointcutExpression.And -> { walk(e.left); walk(e.right) }
+                is PointcutExpression.Or -> { walk(e.left); walk(e.right) }
+                is PointcutExpression.Not -> walk(e.expression)
+                is PointcutExpression.Empty,
+                is PointcutExpression.Execution,
+                is PointcutExpression.Args,
+                -> Unit
+            }
+        }
+        walk(expression)
+        return out
+    }
+
+    private fun namedReferenceClassId(named: PointcutExpression.Named): ClassId {
+        // Named.classId joins packages with "/" which is not a valid FqName component.
+        // Rebuild with dot-separated package parts.
+        val packageFqName = FqName(named.packageNames.joinToString(".") { it.name })
+        val relativeClassName = FqName(named.classNames.joinToString(".") { it.name })
+        return ClassId(packageFqName, relativeClassName, false)
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKDiagnosticRendererFactory.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKDiagnosticRendererFactory.kt
@@ -33,5 +33,15 @@ object AspectKDiagnosticRendererFactory : BaseDiagnosticRendererFactory() {
             message = "{0}",
             rendererA = TO_STRING,
         )
+        put(
+            factory = AspectKErrors.NAMED_POINTCUT_CLASS_NOT_FOUND,
+            message = "Named pointcut reference target class ''{0}'' was not found",
+            rendererA = TO_STRING,
+        )
+        put(
+            factory = AspectKErrors.NAMED_POINTCUT_FUNCTION_NOT_FOUND,
+            message = "@Pointcut function ''{0}'' was not found",
+            rendererA = TO_STRING,
+        )
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
@@ -14,6 +14,8 @@ object AspectKErrors {
     val ASPECT_CLASS_WITH_NO_POINTCUT_OR_ADVICE_ENTRIES by warning0<KtClass>()
     val INVALID_POINTCUT_EXPRESSION by error1<KtFunction, String>()
     val ADVICE_INVALID_SIGNATURE by error1<KtFunction, String>()
+    val NAMED_POINTCUT_CLASS_NOT_FOUND by error1<KtFunction, String>()
+    val NAMED_POINTCUT_FUNCTION_NOT_FOUND by error1<KtFunction, String>()
 
     init {
         RootDiagnosticRendererFactory.registerFactory(AspectKDiagnosticRendererFactory)


### PR DESCRIPTION
## Summary

Walk each parsed pointcut expression, collect every `named(...)` reference, and resolve the target class + `@Pointcut` function via the FIR session's symbol provider. If the lookup fails, emit a precise compile-time error instead of letting the IR phase crash with `IllegalStateException`.

## What gets caught

**Before this PR**, this code compiled cleanly and the failure happened deep in the IR backend with an unhelpful crash:

```kotlin
@Aspect
class MyAspect {
    @Before("named(com/example/DoesNotExist.something)")
    fun before() {}
}
```
```
e: Internal compiler error
   Caused by: java.lang.IllegalStateException:
   Named pointcut com/example/DoesNotExist.something is not found.
```

**After this PR** — class missing on classpath:
```kotlin
@Aspect
class MyAspect {
    @Before("named(com/example/DoesNotExist.something)")
    fun before() {}                         // <-- ERROR (clear, at the call site)
}
```
```
e: MyAspect.kt:3:5: Named pointcut reference target class
   'com.example.DoesNotExist' was not found
```

**Class exists but no matching `@Pointcut` function:**
```kotlin
@Aspect
class OtherAspect {
    @Pointcut("execution(public com/example/Foo.bar())")
    fun barCall() {}
}

@Aspect
class MyAspect {
    @Before("named(com/example/OtherAspect.typoInName)")
    fun before() {}                         // <-- ERROR
}
```
```
e: MyAspect.kt:9:5: @Pointcut function
   'com.example.OtherAspect.typoInName' was not found
```

**Still compiles (positive case):**
```kotlin
@Aspect
class OtherAspect {
    @Pointcut("execution(public com/example/Foo.bar())")
    fun barCall() {}
}

@Aspect
class MyAspect {
    @Before("named(com/example/OtherAspect.barCall)")
    fun before() {}                         // OK
}
```

## Implementation notes

- `PointcutExpression.Named.classId` joins package parts with `/`, which isn't a valid `FqName` component. The checker rebuilds the `ClassId` with dot-joined package parts before looking up via `session.symbolProvider.getClassLikeSymbolByClassId(...)`.
- Only `named(...)` references are validated. `execution(...)` target classes are intentionally not checked — they routinely target third-party code that may not be on the classpath at all.
- And/Or/Not nodes in the pointcut tree are walked recursively so `named(...)` inside `execution(...) && named(...)` is still validated.

## Test plan

- [x] `./gradlew :aspectk-compiler:compileKotlin` passes
- [ ] Manually verify the error fires by temporarily adding `@Pointcut("named(com/does/not/Exist.foo)")` in `test/.../LogAspect.kt` and checking both diagnostics appear
