### PR TITLE
Enrich JoinPoint with method identification fields

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKConsts.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKConsts.kt
@@ -8,5 +8,6 @@ import org.jetbrains.kotlin.name.Name
 object AspectKConsts {
     val JOIN_POINT_CLASS_ID = classId("com.github.kitakkun.aspectk.core", "JoinPoint")
     val JOIN_POINT_FQ_NAME = JOIN_POINT_CLASS_ID.asSingleFqName()
+    val JOIN_POINT_ARGUMENT_CLASS_ID = classId("com.github.kitakkun.aspectk.core", "JoinPointArgument")
     val LIST_OF_FUNCTION_ID = CallableId(FqName("kotlin.collections"), Name.identifier("listOf"))
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrPluginContext.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrPluginContext.kt
@@ -8,6 +8,8 @@ import org.jetbrains.kotlin.ir.util.isVararg
 
 class AspectKIrPluginContext(val context: IrPluginContext, val messageCollector: MessageCollector) : IrPluginContext by context {
     val joinPointClassConstructor = referenceClass(AspectKConsts.JOIN_POINT_CLASS_ID)?.constructors?.first { it.owner.isPrimary }!!
+    val joinPointArgumentClassConstructor =
+        referenceClass(AspectKConsts.JOIN_POINT_ARGUMENT_CLASS_ID)?.constructors?.first { it.owner.isPrimary }!!
     val listOfFunction = referenceFunctions(AspectKConsts.LIST_OF_FUNCTION_ID).first {
         it.owner.valueParameters.size == 1 && it.owner.valueParameters.first().isVararg
     }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/ApplyAdviceTransformer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/ApplyAdviceTransformer.kt
@@ -7,11 +7,20 @@ import com.github.kitakkun.aspectk.compiler.backend.utils.irBlockBuilder
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.deepCopyWithVariables
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
+import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
+import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.types.classifierOrFail
+import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.types.makeNotNull
+import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.ir.util.isObject
+import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 
@@ -65,17 +74,93 @@ private fun IrStatementsBuilder<*>.generateAspectInstance(aspectClass: IrClass):
 
 context(AspectKIrPluginContext)
 private fun IrStatementsBuilder<*>.generateJoinPointVariable(declaration: IrFunction): IrVariable {
+    val methodName = declaration.name.asString()
+    val targetClassName = declaration.parentClassOrNull?.classId?.asFqNameString() ?: ""
+    val signature = buildSignatureText(declaration, methodName, targetClassName)
+    val contextReceiverCount = declaration.contextReceiverParametersCount
+    val contextParams = declaration.valueParameters.take(contextReceiverCount)
+    val valueParams = declaration.valueParameters.drop(contextReceiverCount)
+
     return irTemporary(
         irCallConstructor(joinPointClassConstructor, emptyList()).apply {
-            putValueArgument(0, declaration.dispatchReceiverParameter?.let { irGet(it) } ?: irNull())
-            putValueArgument(
-                1,
-                irCall(listOfFunction).apply {
-                    putValueArgument(index = 0, valueArgument = irVararg(irBuiltIns.anyNType, declaration.valueParameters.map { irGet(it) }))
-                },
-            )
+            putValueArgument(0, declaration.dispatchReceiverParameter?.let { irJoinPointArgument(it) } ?: irNull())
+            putValueArgument(1, declaration.extensionReceiverParameter?.let { irJoinPointArgument(it) } ?: irNull())
+            putValueArgument(2, irJoinPointArgumentList(contextParams))
+            putValueArgument(3, irJoinPointArgumentList(valueParams))
+            putValueArgument(4, irString(methodName))
+            putValueArgument(5, irString(targetClassName))
+            putValueArgument(6, irString(signature))
         },
     )
+}
+
+context(AspectKIrPluginContext)
+private fun IrBuilderWithScope.irJoinPointArgument(parameter: IrValueParameter): IrExpression {
+    return irCallConstructor(joinPointArgumentClassConstructor, emptyList()).apply {
+        putValueArgument(0, irString(parameter.name.asString()))
+        putValueArgument(1, irKClassReference(parameter.type))
+        putValueArgument(2, irGet(parameter))
+        putValueArgument(3, irAnnotationList(parameter.annotations))
+    }
+}
+
+context(AspectKIrPluginContext)
+private fun IrBuilderWithScope.irJoinPointArgumentList(params: List<IrValueParameter>): IrExpression {
+    val argumentType = referenceClass(AspectKConsts.JOIN_POINT_ARGUMENT_CLASS_ID)!!.defaultType
+    return irCall(listOfFunction).apply {
+        putValueArgument(
+            index = 0,
+            valueArgument = irVararg(argumentType, params.map { irJoinPointArgument(it) }),
+        )
+    }
+}
+
+private fun IrBuilderWithScope.irKClassReference(type: IrType): IrExpression {
+    val erased = type.makeNotNull()
+    return IrClassReferenceImpl(
+        startOffset = startOffset,
+        endOffset = endOffset,
+        type = context.irBuiltIns.kClassClass.typeWith(erased),
+        symbol = erased.classifierOrFail,
+        classType = erased,
+    )
+}
+
+context(AspectKIrPluginContext)
+private fun IrBuilderWithScope.irAnnotationList(annotations: List<IrConstructorCall>): IrExpression {
+    return irCall(listOfFunction).apply {
+        putValueArgument(
+            index = 0,
+            valueArgument = irVararg(
+                irBuiltIns.annotationType,
+                annotations.map { it.deepCopyWithVariables() },
+            ),
+        )
+    }
+}
+
+private fun buildSignatureText(
+    declaration: IrFunction,
+    methodName: String,
+    targetClassName: String,
+): String {
+    val contextReceiverCount = declaration.contextReceiverParametersCount
+    val contextFqns = declaration.valueParameters.take(contextReceiverCount)
+        .map { it.type.classOrNull?.owner?.classId?.asFqNameString() ?: "?" }
+    val extensionFqn = declaration.extensionReceiverParameter
+        ?.type?.classOrNull?.owner?.classId?.asFqNameString()
+    val valueFqns = declaration.valueParameters.drop(contextReceiverCount)
+        .map { it.type.classOrNull?.owner?.classId?.asFqNameString() ?: "?" }
+    val returnFqn = declaration.returnType.classOrNull?.owner?.classId?.asFqNameString() ?: "?"
+
+    val contextPart = if (contextFqns.isEmpty()) "" else "context(${contextFqns.joinToString(", ")}) "
+    val receiverPart = extensionFqn?.let { "$it." } ?: ""
+    val qualifier = when {
+        receiverPart.isNotEmpty() -> "$receiverPart$methodName"
+        targetClassName.isEmpty() -> methodName
+        else -> "$targetClassName.$methodName"
+    }
+    return "$contextPart$qualifier(${valueFqns.joinToString(", ")}): $returnFqn"
 }
 
 private fun IrBuilderWithScope.adviceCall(

--- a/aspectk-core/src/commonMain/kotlin/com/github/kitakkun/aspectk/core/JoinPoint.kt
+++ b/aspectk-core/src/commonMain/kotlin/com/github/kitakkun/aspectk/core/JoinPoint.kt
@@ -1,6 +1,20 @@
 package com.github.kitakkun.aspectk.core
 
+import kotlin.reflect.KClass
+
 data class JoinPoint(
-    val parentClass: Any?,
-    val args: List<Any?>,
+    val dispatchReceiver: JoinPointArgument?,
+    val extensionReceiver: JoinPointArgument?,
+    val contextArguments: List<JoinPointArgument>,
+    val valueArguments: List<JoinPointArgument>,
+    val methodName: String,
+    val targetClassName: String,
+    val signature: String,
+)
+
+data class JoinPointArgument(
+    val name: String,
+    val type: KClass<*>,
+    val value: Any?,
+    val annotations: List<Annotation>,
 )


### PR DESCRIPTION
## Summary

Expose every value the IR has at the call site as a uniformly-shaped `JoinPointArgument`, so advice can pick exactly what it needs (name, type, value, annotations) without re-deriving it via reflection on the receiver instance.

## API change

**Before:**
```kotlin
data class JoinPoint(
    val parentClass: Any?,
    val args: List<Any?>,
)
```

**After:**
```kotlin
data class JoinPoint(
    val dispatchReceiver: JoinPointArgument?,    // null for top-level / extension functions
    val extensionReceiver: JoinPointArgument?,   // null for non-extension functions
    val contextArguments: List<JoinPointArgument>,
    val valueArguments: List<JoinPointArgument>,
    val methodName: String,
    val targetClassName: String,
    val signature: String,
)

data class JoinPointArgument(
    val name: String,            // source parameter name (or "<this>" for receivers)
    val type: KClass<*>,         // declared static type
    val value: Any?,             // runtime value
    val annotations: List<Annotation>,
)
```

Receivers, context receivers, and value parameters are all represented the same way, so a single helper can introspect any of them.

## What the advice can now do

**Logging arg names + values + annotations** (the canonical use case):
```kotlin
@Aspect
class TracingAspect {
    @Before("execution(public com/example/Repo.*(..))")
    fun trace(jp: JoinPoint) {
        val argsText = jp.valueArguments.joinToString(", ") {
            "${it.name}=${it.value}"
        }
        println("→ ${jp.signature} [$argsText]")
    }
}
```

For a call to `Repo.upsert(id = 42, name = "alice")` this prints:
```
→ com.example.Repo.upsert(kotlin.Int, kotlin.String): kotlin.Unit [id=42, name=alice]
```

**Per-parameter metadata via `@Sensitive` annotation:**
```kotlin
class Repo {
    fun login(@Sensitive password: String) { … }
}

@Aspect
class RedactingAspect {
    @Before("execution(public com/example/Repo.*(..))")
    fun trace(jp: JoinPoint) {
        val argsText = jp.valueArguments.joinToString(", ") { arg ->
            val v = if (arg.annotations.any { it is Sensitive }) "<redacted>" else arg.value
            "${arg.name}=$v"
        }
        println("→ ${jp.signature} [$argsText]")
    }
}
```

**Type-driven dispatch:**
```kotlin
@Before("execution(public com/example/**(..))")
fun trace(jp: JoinPoint) {
    jp.valueArguments.forEach { arg ->
        when (arg.type) {
            ByteArray::class -> println("${arg.name}: <${(arg.value as ByteArray).size} bytes>")
            else             -> println("${arg.name}: ${arg.value}")
        }
    }
}
```

**Sample runtime output** for `ExampleClass.fuuu(int: Int)` called with `42`:
```
JoinPoint(
  dispatchReceiver = JoinPointArgument(
    name = "<this>", type = ExampleClass, value = ExampleClass@…, annotations = []
  ),
  extensionReceiver = null,
  contextArguments = [],
  valueArguments = [
    JoinPointArgument(name = "int", type = Int, value = 42, annotations = [])
  ],
  methodName = "fuuu",
  targetClassName = "com.…ExampleClass",
  signature = "com.…ExampleClass.fuuu(kotlin.Int): kotlin.Unit",
)
```

## IR-side wiring

`ApplyAdviceTransformer.generateJoinPointVariable` now:
1. Looks up the `JoinPointArgument` primary constructor in `AspectKIrPluginContext`.
2. Partitions `IrFunction.valueParameters` using `contextReceiverParametersCount` so context receivers and value parameters land in separate `List<JoinPointArgument>`s.
3. For each receiver / context / value parameter, emits `JoinPointArgument(name, T::class, paramRef, listOf(annotations))`.
4. The `KClass` reference is emitted via `IrClassReferenceImpl`; the annotation list is `listOf<Annotation>(...)` over deep-copied `IrConstructorCall`s from the parameter's IR annotations.

## Dependencies

`KClass<*>` is part of `kotlin-stdlib`. AspectK consumers do **not** need to add a `kotlin-reflect` dependency — stdlib operations (`type.toString()`, `is` checks, identity comparisons) work without it. `kotlin-reflect` is only needed if the advice itself wants to call APIs like `KClass.members`, `KClass.simpleName`, etc.

## Breaking change

`JoinPoint.parentClass` / `JoinPoint.args` are gone, replaced by the structured fields above. AspectK is pre-1.0 (the README marks it as under development), so this is acceptable.

## Test plan

- [x] `./gradlew :aspectk-core:compileKotlinJvm :aspectk-compiler:compileKotlin` passes
- [x] `:test:compileKotlinJvm` runs and prints the rich `JoinPoint.toString()` shown above

## Related

- Required by #11 (`@Around` / `ProceedingJoinPoint`), which reuses `JoinPointArgument` on the PJP type.
