### PR TITLE
Implement @Around with ProceedingJoinPoint

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKConsts.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKConsts.kt
@@ -8,6 +8,9 @@ import org.jetbrains.kotlin.name.Name
 object AspectKConsts {
     val JOIN_POINT_CLASS_ID = classId("com.github.kitakkun.aspectk.core", "JoinPoint")
     val JOIN_POINT_FQ_NAME = JOIN_POINT_CLASS_ID.asSingleFqName()
+    val STATIC_JOIN_POINT_CLASS_ID = classId("com.github.kitakkun.aspectk.core", "StaticJoinPoint")
     val JOIN_POINT_ARGUMENT_CLASS_ID = classId("com.github.kitakkun.aspectk.core", "JoinPointArgument")
+    val PROCEEDING_JOIN_POINT_CLASS_ID = classId("com.github.kitakkun.aspectk.core", "ProceedingJoinPoint")
+    val PROCEEDING_JOIN_POINT_FQ_NAME = PROCEEDING_JOIN_POINT_CLASS_ID.asSingleFqName()
     val LIST_OF_FUNCTION_ID = CallableId(FqName("kotlin.collections"), Name.identifier("listOf"))
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrPluginContext.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrPluginContext.kt
@@ -7,9 +7,11 @@ import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.isVararg
 
 class AspectKIrPluginContext(val context: IrPluginContext, val messageCollector: MessageCollector) : IrPluginContext by context {
-    val joinPointClassConstructor = referenceClass(AspectKConsts.JOIN_POINT_CLASS_ID)?.constructors?.first { it.owner.isPrimary }!!
+    val joinPointClassConstructor = referenceClass(AspectKConsts.STATIC_JOIN_POINT_CLASS_ID)?.constructors?.first { it.owner.isPrimary }!!
     val joinPointArgumentClassConstructor =
         referenceClass(AspectKConsts.JOIN_POINT_ARGUMENT_CLASS_ID)?.constructors?.first { it.owner.isPrimary }!!
+    val proceedingJoinPointClassConstructor =
+        referenceClass(AspectKConsts.PROCEEDING_JOIN_POINT_CLASS_ID)?.constructors?.first { it.owner.isPrimary }!!
     val listOfFunction = referenceFunctions(AspectKConsts.LIST_OF_FUNCTION_ID).first {
         it.owner.valueParameters.size == 1 && it.owner.valueParameters.first().isVararg
     }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/ApplyAdviceTransformer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/ApplyAdviceTransformer.kt
@@ -4,25 +4,39 @@ import com.github.kitakkun.aspectk.compiler.AspectKConsts
 import com.github.kitakkun.aspectk.compiler.backend.AspectKIrPluginContext
 import com.github.kitakkun.aspectk.compiler.backend.analyzer.AdviceType
 import com.github.kitakkun.aspectk.compiler.backend.utils.irBlockBuilder
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.deepCopyWithVariables
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.expressions.IrReturn
+import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
 import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrFunctionExpressionImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrReturnImpl
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.types.isUnit
 import org.jetbrains.kotlin.ir.types.makeNotNull
 import org.jetbrains.kotlin.ir.types.typeWith
+import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.classId
+import org.jetbrains.kotlin.ir.util.patchDeclarationParents
 import org.jetbrains.kotlin.ir.util.isObject
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+import org.jetbrains.kotlin.name.SpecialNames
 
 context(AspectKIrPluginContext)
 class ApplyAdviceTransformer(
@@ -34,6 +48,14 @@ class ApplyAdviceTransformer(
     override fun visitSimpleFunction(declaration: IrSimpleFunction): IrStatement {
         if (declaration.symbol != targetFunction.symbol) return declaration
 
+        when (adviceType) {
+            AdviceType.BEFORE, AdviceType.AFTER -> applyBeforeOrAfter(declaration)
+            AdviceType.AROUND -> applyAround(declaration)
+        }
+        return declaration
+    }
+
+    private fun applyBeforeOrAfter(declaration: IrSimpleFunction) {
         val irBuilder = declaration.irBlockBuilder(context)
         val aspectInstance = irBuilder.generateAspectInstance(aspectClass)
         val joinPointVariable = irBuilder.generateJoinPointVariable(declaration)
@@ -49,15 +71,133 @@ class ApplyAdviceTransformer(
         when (adviceType) {
             AdviceType.AFTER -> AfterAdviceFunctionBodyTransformer(targetFunction, adviceCall).visitSimpleFunction(declaration)
             AdviceType.BEFORE -> BeforeAdviceTransformer(targetFunction, adviceCall).visitSimpleFunction(declaration)
-            AdviceType.AROUND -> {
-                // TODO: Implement AroundAdviceTransformer
-                BeforeAdviceTransformer(targetFunction, adviceCall).visitSimpleFunction(declaration)
-                AfterAdviceFunctionBodyTransformer(targetFunction, adviceCall).visitSimpleFunction(declaration)
+            AdviceType.AROUND -> error("unreachable")
+        }
+    }
+
+    private fun applyAround(declaration: IrSimpleFunction) {
+        val originalBody = declaration.body as? IrBlockBody ?: return
+
+        val lambdaFn = buildProceedLambda(declaration, originalBody)
+        val function0Type = irBuiltIns.functionN(0).typeWith(irBuiltIns.anyNType)
+        val lambdaExpr: IrFunctionExpression = IrFunctionExpressionImpl(
+            startOffset = SYNTHETIC_OFFSET,
+            endOffset = SYNTHETIC_OFFSET,
+            type = function0Type,
+            function = lambdaFn,
+            origin = IrStatementOrigin.LAMBDA,
+        )
+
+        val newBody = declaration.irBlockBuilder(context).run {
+            irBlockBody {
+                val aspectInstance = generateAspectInstance(aspectClass)
+                val pjpVariable = generateProceedingJoinPointVariable(declaration, lambdaExpr)
+                val adviceCallExpr = adviceAroundCall(adviceFunction, aspectInstance, pjpVariable)
+                if (declaration.returnType.isUnit()) {
+                    +adviceCallExpr
+                } else {
+                    +irReturn(irImplicitCast(adviceCallExpr, declaration.returnType))
+                }
             }
         }
-
-        return declaration
+        declaration.body = newBody
     }
+
+    private fun buildProceedLambda(
+        declaration: IrSimpleFunction,
+        originalBody: IrBlockBody,
+    ): IrSimpleFunction {
+        val lambdaFn = irFactory.buildFun {
+            startOffset = SYNTHETIC_OFFSET
+            endOffset = SYNTHETIC_OFFSET
+            origin = IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA
+            name = SpecialNames.NO_NAME_PROVIDED
+            visibility = DescriptorVisibilities.LOCAL
+            modality = Modality.FINAL
+            returnType = irBuiltIns.anyNType
+        }
+        lambdaFn.parent = declaration
+
+        val moved = originalBody.deepCopyWithVariables()
+        moved.transformChildrenVoid(
+            ReturnRetargeter(
+                originalFn = declaration.symbol,
+                newFn = lambdaFn.symbol,
+                newReturnType = irBuiltIns.anyNType,
+            ),
+        )
+        // If the body doesn't end in an IrReturn (Unit-returning function with no explicit return),
+        // append `return Unit` so the lambda returns Any?.
+        if (moved.statements.lastOrNull() !is IrReturn) {
+            val unitGet = declaration.irBlockBuilder(context).irGetObject(irBuiltIns.unitClass)
+            moved.statements.add(
+                IrReturnImpl(
+                    SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
+                    irBuiltIns.nothingType, lambdaFn.symbol, unitGet,
+                ),
+            )
+        }
+        lambdaFn.body = moved
+        lambdaFn.patchDeclarationParents(declaration)
+        return lambdaFn
+    }
+
+    context(AspectKIrPluginContext)
+    private fun IrStatementsBuilder<*>.generateProceedingJoinPointVariable(
+        declaration: IrSimpleFunction,
+        proceedLambda: IrFunctionExpression,
+    ): IrVariable {
+        val methodName = declaration.name.asString()
+        val targetClassName = declaration.parentClassOrNull?.classId?.asFqNameString() ?: ""
+        val signature = buildSignatureText(declaration, methodName, targetClassName)
+        val contextReceiverCount = declaration.contextReceiverParametersCount
+        val contextParams = declaration.valueParameters.take(contextReceiverCount)
+        val valueParams = declaration.valueParameters.drop(contextReceiverCount)
+
+        return irTemporary(
+            irCallConstructor(proceedingJoinPointClassConstructor, emptyList()).apply {
+                putValueArgument(0, declaration.dispatchReceiverParameter?.let { irJoinPointArgument(it) } ?: irNull())
+                putValueArgument(1, declaration.extensionReceiverParameter?.let { irJoinPointArgument(it) } ?: irNull())
+                putValueArgument(2, irJoinPointArgumentList(contextParams))
+                putValueArgument(3, irJoinPointArgumentList(valueParams))
+                putValueArgument(4, irString(methodName))
+                putValueArgument(5, irString(targetClassName))
+                putValueArgument(6, irString(signature))
+                putValueArgument(7, proceedLambda)
+            },
+        )
+    }
+
+    private fun IrBuilderWithScope.adviceAroundCall(
+        functionDeclaration: IrSimpleFunction,
+        aspectInstance: IrVariable,
+        pjpVariable: IrVariable,
+    ): IrExpression {
+        return irCall(functionDeclaration.symbol).apply {
+            dispatchReceiver = irGet(aspectInstance)
+            if (functionDeclaration.valueParameters.isNotEmpty()) {
+                putValueArgument(0, irGet(pjpVariable))
+            }
+        }
+    }
+}
+
+private class ReturnRetargeter(
+    private val originalFn: IrSimpleFunctionSymbol,
+    private val newFn: IrSimpleFunctionSymbol,
+    private val newReturnType: IrType,
+) : IrElementTransformerVoid() {
+    override fun visitReturn(expression: IrReturn): IrExpression {
+        if (expression.returnTargetSymbol != originalFn) return super.visitReturn(expression)
+        return IrReturnImpl(
+            expression.startOffset, expression.endOffset,
+            newReturnType, newFn, expression.value,
+        )
+    }
+
+    override fun visitFunctionExpression(expression: IrFunctionExpression): IrExpression = expression
+
+    override fun visitFunction(declaration: IrFunction): IrStatement = declaration
 }
 
 private fun IrStatementsBuilder<*>.generateAspectInstance(aspectClass: IrClass): IrVariable {

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AdviceSignatureChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AdviceSignatureChecker.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.hasAnnotation
 import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.fir.types.coneType
+import org.jetbrains.kotlin.name.ClassId
 
 class AdviceSignatureChecker : FirFunctionChecker() {
     override fun check(
@@ -18,7 +19,9 @@ class AdviceSignatureChecker : FirFunctionChecker() {
         reporter: DiagnosticReporter,
     ) {
         with(context) {
-            val adviceAnnotationShortName = adviceAnnotationShortName(declaration) ?: return
+            val adviceKind = adviceKind(declaration) ?: return
+            val allowedJoinPointTypes = adviceKind.allowedJoinPointTypes()
+            val allowedNames = allowedJoinPointTypes.joinToString(" or ") { it.shortClassName.asString() }
 
             val params = declaration.valueParameters
             when {
@@ -26,11 +29,11 @@ class AdviceSignatureChecker : FirFunctionChecker() {
 
                 params.size == 1 -> {
                     val paramType = params.single().returnTypeRef.coneType
-                    if (paramType.classId != AspectKConsts.JOIN_POINT_CLASS_ID) {
+                    if (paramType.classId !in allowedJoinPointTypes) {
                         reporter.reportOn(
                             declaration.source,
                             AspectKErrors.ADVICE_INVALID_SIGNATURE,
-                            "@$adviceAnnotationShortName advice must take either no parameters or a single ${AspectKConsts.JOIN_POINT_CLASS_ID.shortClassName.asString()} parameter",
+                            "@${adviceKind.shortName} advice must take either no parameters or a single $allowedNames parameter",
                         )
                     }
                 }
@@ -39,22 +42,31 @@ class AdviceSignatureChecker : FirFunctionChecker() {
                     reporter.reportOn(
                         declaration.source,
                         AspectKErrors.ADVICE_INVALID_SIGNATURE,
-                        "@$adviceAnnotationShortName advice must take either no parameters or a single ${AspectKConsts.JOIN_POINT_CLASS_ID.shortClassName.asString()} parameter (got ${params.size} parameters)",
+                        "@${adviceKind.shortName} advice must take either no parameters or a single $allowedNames parameter (got ${params.size} parameters)",
                     )
                 }
             }
         }
     }
 
+    private enum class AdviceKind(val shortName: String) {
+        BEFORE("Before"),
+        AFTER("After"),
+        AROUND("Around"),
+        ;
+
+        fun allowedJoinPointTypes(): Set<ClassId> = when (this) {
+            BEFORE, AFTER -> setOf(AspectKConsts.JOIN_POINT_CLASS_ID)
+            AROUND -> setOf(AspectKConsts.JOIN_POINT_CLASS_ID, AspectKConsts.PROCEEDING_JOIN_POINT_CLASS_ID)
+        }
+    }
+
     context(CheckerContext)
-    private fun adviceAnnotationShortName(declaration: FirFunction): String? {
+    private fun adviceKind(declaration: FirFunction): AdviceKind? {
         return when {
-            declaration.hasAnnotation(AspectKAnnotations.BEFORE_CLASS_ID, session) ->
-                AspectKAnnotations.BEFORE_CLASS_ID.shortClassName.asString()
-            declaration.hasAnnotation(AspectKAnnotations.AFTER_CLASS_ID, session) ->
-                AspectKAnnotations.AFTER_CLASS_ID.shortClassName.asString()
-            declaration.hasAnnotation(AspectKAnnotations.AROUND_CLASS_ID, session) ->
-                AspectKAnnotations.AROUND_CLASS_ID.shortClassName.asString()
+            declaration.hasAnnotation(AspectKAnnotations.BEFORE_CLASS_ID, session) -> AdviceKind.BEFORE
+            declaration.hasAnnotation(AspectKAnnotations.AFTER_CLASS_ID, session) -> AdviceKind.AFTER
+            declaration.hasAnnotation(AspectKAnnotations.AROUND_CLASS_ID, session) -> AdviceKind.AROUND
             else -> null
         }
     }

--- a/aspectk-core/src/commonMain/kotlin/com/github/kitakkun/aspectk/core/JoinPoint.kt
+++ b/aspectk-core/src/commonMain/kotlin/com/github/kitakkun/aspectk/core/JoinPoint.kt
@@ -2,7 +2,7 @@ package com.github.kitakkun.aspectk.core
 
 import kotlin.reflect.KClass
 
-data class JoinPoint(
+sealed class JoinPoint(
     val dispatchReceiver: JoinPointArgument?,
     val extensionReceiver: JoinPointArgument?,
     val contextArguments: List<JoinPointArgument>,
@@ -10,6 +10,35 @@ data class JoinPoint(
     val methodName: String,
     val targetClassName: String,
     val signature: String,
+) {
+    override fun toString(): String =
+        "${this::class.simpleName ?: "JoinPoint"}(" +
+            "dispatchReceiver=$dispatchReceiver, " +
+            "extensionReceiver=$extensionReceiver, " +
+            "contextArguments=$contextArguments, " +
+            "valueArguments=$valueArguments, " +
+            "methodName=$methodName, " +
+            "targetClassName=$targetClassName, " +
+            "signature=$signature" +
+            ")"
+}
+
+class StaticJoinPoint(
+    dispatchReceiver: JoinPointArgument?,
+    extensionReceiver: JoinPointArgument?,
+    contextArguments: List<JoinPointArgument>,
+    valueArguments: List<JoinPointArgument>,
+    methodName: String,
+    targetClassName: String,
+    signature: String,
+) : JoinPoint(
+    dispatchReceiver = dispatchReceiver,
+    extensionReceiver = extensionReceiver,
+    contextArguments = contextArguments,
+    valueArguments = valueArguments,
+    methodName = methodName,
+    targetClassName = targetClassName,
+    signature = signature,
 )
 
 data class JoinPointArgument(

--- a/aspectk-core/src/commonMain/kotlin/com/github/kitakkun/aspectk/core/ProceedingJoinPoint.kt
+++ b/aspectk-core/src/commonMain/kotlin/com/github/kitakkun/aspectk/core/ProceedingJoinPoint.kt
@@ -1,0 +1,28 @@
+package com.github.kitakkun.aspectk.core
+
+class ProceedingJoinPoint(
+    dispatchReceiver: JoinPointArgument?,
+    extensionReceiver: JoinPointArgument?,
+    contextArguments: List<JoinPointArgument>,
+    valueArguments: List<JoinPointArgument>,
+    methodName: String,
+    targetClassName: String,
+    signature: String,
+    private val proceedFn: () -> Any?,
+) : JoinPoint(
+    dispatchReceiver = dispatchReceiver,
+    extensionReceiver = extensionReceiver,
+    contextArguments = contextArguments,
+    valueArguments = valueArguments,
+    methodName = methodName,
+    targetClassName = targetClassName,
+    signature = signature,
+) {
+    fun proceed(): Any? = proceedFn()
+
+    fun proceed(newArgs: List<Any?>): Any? {
+        throw UnsupportedOperationException(
+            "ProceedingJoinPoint.proceed(newArgs) is not supported yet; use proceed() to invoke the original method with captured arguments.",
+        )
+    }
+}

--- a/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/AspectExample.kt
+++ b/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/AspectExample.kt
@@ -5,6 +5,7 @@ import com.github.kitakkun.aspectk.annotations.Around
 import com.github.kitakkun.aspectk.annotations.Aspect
 import com.github.kitakkun.aspectk.annotations.Before
 import com.github.kitakkun.aspectk.core.JoinPoint
+import com.github.kitakkun.aspectk.core.ProceedingJoinPoint
 
 @Aspect
 class AspectExample {
@@ -24,8 +25,10 @@ class AspectExample {
     }
 
     @Around("execution(public com/github/kitakkun/aspectk/test/ExampleClass.*())")
-    fun aroundExampleClassMethod(joinPoint: JoinPoint) {
-        println(joinPoint)
-        println("Around ExampleClass method call")
+    fun aroundExampleClassMethod(joinPoint: ProceedingJoinPoint): Any? {
+        println("Around: before proceed for ${joinPoint.signature}")
+        val result = joinPoint.proceed()
+        println("Around: after proceed for ${joinPoint.signature} (result=$result)")
+        return result
     }
 }


### PR DESCRIPTION
## Summary

Make `@Around` actually work, and at the same time express the JoinPoint hierarchy as a single shared `sealed class` so the static/proceedable variants don't duplicate the seven identification + argument fields.

Before this PR, `@Around` silently fell back to running both `@Before` and `@After` sequentially — `proceed()` didn't exist, the advice couldn't wrap the original method, substitute its return value, or short-circuit it.

## Type hierarchy

```kotlin
sealed class JoinPoint(
    val dispatchReceiver: JoinPointArgument?,
    val extensionReceiver: JoinPointArgument?,
    val contextArguments: List<JoinPointArgument>,
    val valueArguments: List<JoinPointArgument>,
    val methodName: String,
    val targetClassName: String,
    val signature: String,
)

class StaticJoinPoint(…) : JoinPoint(…)         // what @Before / @After receive

class ProceedingJoinPoint(…, proceedFn) : JoinPoint(…) {
    fun proceed(): Any? = proceedFn()
    fun proceed(newArgs: List<Any?>): Any?       // throws UnsupportedOperationException for now
}
```

Advice signatures see only the common supertype:

```kotlin
@Before("…")  fun before(jp: JoinPoint) { … }            // gets a StaticJoinPoint at runtime
@After("…")   fun after(jp: JoinPoint) { … }             // gets a StaticJoinPoint at runtime
@Around("…")  fun around(pjp: ProceedingJoinPoint) { … } // gets a ProceedingJoinPoint, can call proceed()
```

`sealed` instead of `open` because no external library is expected to subclass `JoinPoint` — the only two valid implementations are owned by `aspectk-core`.

## What advice authors can now write

```kotlin
@Aspect
class TimingAspect {
    @Around("execution(public com/example/Repository.*(..))")
    fun timed(pjp: ProceedingJoinPoint): Any? {
        val start = System.nanoTime()
        try {
            return pjp.proceed()                            // runs the original method
        } finally {
            val ms = (System.nanoTime() - start) / 1_000_000
            println("${pjp.signature} took ${ms}ms")
        }
    }
}
```

```kotlin
@Aspect
class CacheAspect {
    private val cache = mutableMapOf<List<Any?>, Any?>()

    @Around("execution(public com/example/Repository.find(..))")
    fun cached(pjp: ProceedingJoinPoint): Any? {
        val key = pjp.valueArguments.map { it.value }
        return cache.getOrPut(key) { pjp.proceed() }        // can skip proceed() entirely
    }
}
```

```kotlin
@Aspect
class RetryAspect {
    @Around("execution(public com/example/Net.*(..))")
    fun retry(pjp: ProceedingJoinPoint): Any? {
        var last: Throwable? = null
        repeat(3) {
            try { return pjp.proceed() } catch (e: IOException) { last = e }   // multiple proceed() is fine
        }
        throw last!!
    }
}
```

## How the IR transformation works

For an original function:
```kotlin
class ExampleClass {
    fun foo(a: Int): String = "x$a"
}
```

The transformer rewrites `foo` to (in pseudocode):
```kotlin
fun foo(a: Int): String {
    val aspect = TimingAspect()
    val pjp = ProceedingJoinPoint(
        dispatchReceiver = JoinPointArgument("<this>", ExampleClass::class, this, emptyList()),
        extensionReceiver = null,
        contextArguments = emptyList(),
        valueArguments = listOf(JoinPointArgument("a", Int::class, a, emptyList())),
        methodName = "foo",
        targetClassName = "com.example.ExampleClass",
        signature = "com.example.ExampleClass.foo(kotlin.Int): kotlin.String",
        proceedFn = {              // original body lifted into a lambda
            "x$a"                  // IrReturn targets retargeted from foo to the lambda
        },
    )
    return aspect.timed(pjp) as String   // cast Any? back to original return type
}
```

Concretely:
1. Snapshot the original `IrBlockBody` and move it into a synthetic `() -> Any?` lambda, retargeting `IrReturn` statements to the lambda so they return from `proceed()` rather than the wrapped function.
2. Build a `ProceedingJoinPoint`, passing each receiver / argument as a `JoinPointArgument` and the lambda as `proceedFn`.
3. Replace the function body with a call to the advice passing the PJP, casting the advice's `Any?` result back to the original return type (or discarding it for `Unit`-returning functions).

`@Before` / `@After` keep their existing path; the only IR-level change is that they now instantiate `StaticJoinPoint` (the concrete subclass) instead of `JoinPoint` directly, since `JoinPoint` is now `sealed`/abstract.

## Advice signature checker

`AdviceSignatureChecker` (from #8, now on `develop`) is extended on this branch so `@Around` advice may take a single `ProceedingJoinPoint` parameter in addition to `JoinPoint`. The allowed-types set is per-advice-kind, so the diagnostic naturally names whichever type applies. `@Before` / `@After` continue to accept only `JoinPoint` (or no parameter).

## Verification (runtime trace)

The `test/` sample's `@Around` advice is updated to take a `ProceedingJoinPoint` and call `proceed()`. With all three advices on `ExampleClass.hoge()`, running `main()` prints:

```
Around: before proceed for com.…ExampleClass.hoge(): kotlin.Unit
Before ExampleClass method call
hoge
After ExampleClass method call
StaticJoinPoint(dispatchReceiver=…, valueArguments=[], …)
Around: after proceed for com.…ExampleClass.hoge(): kotlin.Unit (result=kotlin.Unit)
```

The around advice correctly wraps `@Before`, the original body, and `@After`, and `JoinPoint.toString()` reports the concrete subclass name.

## Limitations (follow-up)

- `proceed(newArgs)` throws `UnsupportedOperationException`. Supporting argument rebinding would require extracting the original body into a private method whose parameters are rebound from the args list — separate PR.

## Breaking change

`JoinPoint` was previously a `data class` (introduced in the merged #10). It is now a `sealed class`, which means:
- The auto-generated `equals`/`hashCode`/`copy` are gone (replaced by a hand-written `toString` that picks up the concrete subclass name).
- The IR can no longer instantiate `JoinPoint` directly — it instantiates `StaticJoinPoint` for `@Before` / `@After`. Advice continues to declare its parameter as `JoinPoint`.

AspectK is pre-1.0 (under development), so this is acceptable.

## Test plan

- [x] `./gradlew :aspectk-compiler:compileKotlin` passes
- [x] `:test:compileKotlinJvm` produces correct bytecode
- [x] Running the compiled `MainKt` shows the expected before/around/after interleaving above
