### PR TITLE
Auto-discover @Aspect classes from classpath dependencies

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKGeneratedRefs.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKGeneratedRefs.kt
@@ -1,0 +1,32 @@
+package com.github.kitakkun.aspectk.compiler
+
+import org.jetbrains.kotlin.GeneratedDeclarationKey
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+object AspectKGeneratedRefs {
+    val PACKAGE: FqName = FqName("com.github.kitakkun.aspectk.generated.refs")
+
+    private const val PREFIX = "Ref_"
+
+    fun classNameFor(aspectFqn: String): Name {
+        return Name.identifier(PREFIX + aspectFqn.encodeToByteArray().joinToString("") {
+            (it.toInt() and 0xFF).toString(16).padStart(2, '0')
+        })
+    }
+
+    fun aspectFqnFor(className: String): String? {
+        if (!className.startsWith(PREFIX)) return null
+        val hex = className.substring(PREFIX.length)
+        if (hex.isEmpty() || hex.length % 2 != 0) return null
+        return runCatching {
+            ByteArray(hex.length / 2) { i ->
+                hex.substring(i * 2, i * 2 + 2).toInt(16).toByte()
+            }.decodeToString()
+        }.getOrNull()
+    }
+}
+
+object AspectKGeneratedDeclarationKey : GeneratedDeclarationKey() {
+    override fun toString(): String = "AspectKAspectRef"
+}

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrGenerationExtension.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrGenerationExtension.kt
@@ -12,7 +12,7 @@ class AspectKIrGenerationExtension(private val messageCollector: MessageCollecto
         moduleFragment: IrModuleFragment,
         pluginContext: IrPluginContext,
     ) {
-        val aspectClasses = AspectAnalyzer.analyze(moduleFragment)
+        val aspectClasses = AspectAnalyzer.analyze(moduleFragment, pluginContext)
 
         val context = AspectKIrPluginContext(pluginContext, messageCollector)
         with(context) {

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectAnalyzer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectAnalyzer.kt
@@ -1,9 +1,12 @@
 package com.github.kitakkun.aspectk.compiler.backend.analyzer
 
 import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import com.github.kitakkun.aspectk.compiler.AspectKGeneratedRefs
 import com.github.kitakkun.aspectk.expression.expressionparser.PointcutExpressionParser
 import com.github.kitakkun.aspectk.expression.lexer.AspectKLexer
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.jvm.ir.getStringConstArgument
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
@@ -13,18 +16,26 @@ import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.simpleFunctions
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 
 class AspectAnalyzer private constructor() : IrElementVisitorVoid {
     companion object {
-        fun analyze(moduleFragment: IrModuleFragment): List<AspectClass> {
+        fun analyze(
+            moduleFragment: IrModuleFragment,
+            pluginContext: IrPluginContext,
+        ): List<AspectClass> {
             with(AspectAnalyzer()) {
                 moduleFragment.acceptChildrenVoid(this)
+                collectExternalAspects(pluginContext)
                 return aspectClassList
             }
         }
     }
 
     private val mutableAspectClassList = mutableListOf<AspectClass>()
+    private val seenClassIds = mutableSetOf<ClassId>()
     val aspectClassList: List<AspectClass> get() = mutableAspectClassList
 
     override fun visitElement(element: IrElement) {
@@ -33,10 +44,54 @@ class AspectAnalyzer private constructor() : IrElementVisitorVoid {
 
     override fun visitClass(declaration: IrClass) {
         if (declaration.hasAnnotation(AspectKAnnotations.ASPECT_FQ_NAME)) {
-            val aspectClass = analyzeClass(declaration)
-            mutableAspectClassList.add(aspectClass)
+            registerAspect(declaration)
         }
         declaration.acceptChildrenVoid(this)
+    }
+
+    private fun registerAspect(declaration: IrClass) {
+        val classId = declaration.classId ?: return
+        if (!seenClassIds.add(classId)) return
+        mutableAspectClassList.add(analyzeClass(declaration))
+    }
+
+    private fun collectExternalAspects(pluginContext: IrPluginContext) {
+        val pkgDescriptor = pluginContext.moduleDescriptor.getPackage(AspectKGeneratedRefs.PACKAGE)
+        val classifiers = pkgDescriptor.memberScope.getContributedDescriptors(
+            kindFilter = DescriptorKindFilter.CLASSIFIERS,
+            nameFilter = { true },
+        ).filterIsInstance<ClassDescriptor>()
+
+        for (refDescriptor in classifiers) {
+            val simpleName = refDescriptor.name.asString()
+            val aspectFqn = AspectKGeneratedRefs.aspectFqnFor(simpleName) ?: continue
+            val aspectClassId = resolveAspectClassId(aspectFqn, pluginContext) ?: continue
+            if (aspectClassId in seenClassIds) continue
+
+            val aspectSymbol = pluginContext.referenceClass(aspectClassId) ?: continue
+            val aspectIrClass = aspectSymbol.owner
+            if (!aspectIrClass.hasAnnotation(AspectKAnnotations.ASPECT_FQ_NAME)) continue
+
+            registerAspect(aspectIrClass)
+        }
+    }
+
+    private fun resolveAspectClassId(fqn: String, pluginContext: IrPluginContext): ClassId? {
+        // Try top-level resolution first (covers the common case). For nested aspects, callers
+        // can still register them by ensuring the marker survives — but they need an explicit
+        // nested-aware ClassId lookup which is not implemented here yet.
+        if (fqn.isBlank()) return null
+        val topLevel = runCatching { ClassId.topLevel(FqName(fqn)) }.getOrNull() ?: return null
+        if (pluginContext.referenceClass(topLevel) != null) return topLevel
+
+        // Fallback: walk the FQN from the right, treating the right-most segment as a nested
+        // class name. Only one level of nesting is attempted.
+        val lastDot = fqn.lastIndexOf('.')
+        if (lastDot <= 0) return null
+        val packageFqName = FqName(fqn.substring(0, fqn.lastIndexOf('.', lastDot - 1).let { if (it == -1) lastDot else it }))
+        val relative = fqn.removePrefix(packageFqName.asString() + ".")
+        val nested = ClassId(packageFqName, FqName(relative), false)
+        return if (pluginContext.referenceClass(nested) != null) nested else null
     }
 
     private fun analyzeClass(declaration: IrClass): AspectClass {

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/AspectKFirExtensionRegistrar.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/AspectKFirExtensionRegistrar.kt
@@ -8,5 +8,6 @@ import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 class AspectKFirExtensionRegistrar : FirExtensionRegistrar() {
     override fun ExtensionRegistrarContext.configurePlugin() {
         +::AspectKFirCheckerExtension
+        +::AspectReferenceGenerator
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/AspectReferenceGenerator.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/AspectReferenceGenerator.kt
@@ -1,0 +1,57 @@
+package com.github.kitakkun.aspectk.compiler.fir
+
+import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import com.github.kitakkun.aspectk.compiler.AspectKGeneratedDeclarationKey
+import com.github.kitakkun.aspectk.compiler.AspectKGeneratedRefs
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
+import org.jetbrains.kotlin.fir.extensions.predicate.DeclarationPredicate
+import org.jetbrains.kotlin.fir.extensions.predicate.LookupPredicate
+import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
+import org.jetbrains.kotlin.fir.plugin.createTopLevelClass
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+
+class AspectReferenceGenerator(session: FirSession) : FirDeclarationGenerationExtension(session) {
+    private val aspectDeclarationPredicate: DeclarationPredicate = DeclarationPredicate.create {
+        annotated(AspectKAnnotations.ASPECT_FQ_NAME)
+    }
+
+    private val aspectLookupPredicate: LookupPredicate = LookupPredicate.create {
+        annotated(AspectKAnnotations.ASPECT_FQ_NAME)
+    }
+
+    override fun FirDeclarationPredicateRegistrar.registerPredicates() {
+        register(aspectDeclarationPredicate)
+    }
+
+    private fun aspectSymbols(): List<FirRegularClassSymbol> {
+        return session.predicateBasedProvider.getSymbolsByPredicate(aspectLookupPredicate)
+            .filterIsInstance<FirRegularClassSymbol>()
+    }
+
+override fun getTopLevelClassIds(): Set<ClassId> {
+        return aspectSymbols().mapTo(mutableSetOf()) { aspectClassIdToRefClassId(it.classId) }
+    }
+
+    override fun hasPackage(packageFqName: FqName): Boolean {
+        return packageFqName == AspectKGeneratedRefs.PACKAGE
+    }
+
+override fun generateTopLevelClassLikeDeclaration(classId: ClassId): FirClassLikeSymbol<*>? {
+        if (classId.packageFqName != AspectKGeneratedRefs.PACKAGE) return null
+        val expectedSimpleName = classId.shortClassName.asString()
+        val originalFqn = AspectKGeneratedRefs.aspectFqnFor(expectedSimpleName) ?: return null
+        val matched = aspectSymbols().firstOrNull { it.classId.asFqNameString() == originalFqn } ?: return null
+        if (aspectClassIdToRefClassId(matched.classId) != classId) return null
+        return createTopLevelClass(classId = classId, key = AspectKGeneratedDeclarationKey).symbol
+    }
+
+    private fun aspectClassIdToRefClassId(aspectClassId: ClassId): ClassId {
+        val refName = AspectKGeneratedRefs.classNameFor(aspectClassId.asFqNameString())
+        return ClassId(AspectKGeneratedRefs.PACKAGE, refName)
+    }
+}


### PR DESCRIPTION
## Summary

Before this PR, `AspectAnalyzer` only walked the IR module fragment for `@Aspect` classes, so aspects compiled into a dependency JAR were silently ignored. This PR makes consumers auto-discover aspects from any module on the classpath. **No Gradle DSL changes** — depending on a module that contains `@Aspect` classes is enough.

## End-to-end example

**Module `:tracing-aspect` defines an aspect:**
```kotlin
// tracing-aspect/src/main/kotlin/com/example/tracing/TracingAspect.kt
package com.example.tracing

import com.github.kitakkun.aspectk.annotations.*
import com.github.kitakkun.aspectk.core.JoinPoint

@Aspect
class TracingAspect {
    @Before("execution(public com/example/app/**(..))")
    fun trace(jp: JoinPoint) {
        println("→ ${jp.signature}")
    }
}
```

**Module `:app` depends on `:tracing-aspect` and writes nothing aspect-related:**
```kotlin
// app/build.gradle.kts
dependencies {
    implementation(project(":tracing-aspect"))
}

// app/src/main/kotlin/com/example/app/Main.kt
package com.example.app

class Repo {
    fun load() = "result"
}

fun main() {
    Repo().load()                           // ← TracingAspect.trace fires here automatically
}
```

Output:
```
→ com.example.app.Repo.load(): kotlin.String
```

Previously, `Repo.load()` would have run with no trace at all — `TracingAspect` lives in a different module so the IR-only scan missed it. **The Gradle build script needed zero changes** beyond depending on the aspect module.

## How it works

**FIR side** — new `AspectReferenceGenerator` (a `FirDeclarationGenerationExtension`) finds every `@Aspect` class in the current module via the predicate system and emits an empty marker class per aspect into the well-known package `com.github.kitakkun.aspectk.generated.refs`. The aspect's FQN is hex-encoded into the marker's simple name so consumers can recover it without parsing annotation arguments.

For `com.example.tracing.TracingAspect`, the FIR plugin generates:
```
com/github/kitakkun/aspectk/generated/refs/Ref_636f6d2e6578616d706c652e74726163696e672e54726163696e6741737065637421
```
(`Ref_<hex of fqn>`)

So `tracing-aspect.jar` ends up containing both `com/example/tracing/TracingAspect.class` and that marker class.

**IR side** — `AspectAnalyzer.analyze(moduleFragment, pluginContext)` now also enumerates classifiers in the well-known package via `pluginContext.moduleDescriptor.getPackage(...).memberScope`, decodes each marker's name back to an FQN, and resolves the actual aspect `IrClass` via `pluginContext.referenceClass(...)`. Module-local aspects are still picked up by the existing IR traversal; deduplication keys on the aspect `ClassId` so they don't get registered twice.

## Known issue

In Kotlin 1.9.x, incremental compilation logs a warning about `__GENERATED DECLARATIONS__.kt` having an unresolvable relative path, then falls back to non-incremental compilation. The build still succeeds and the output is correct. This is a known limitation of `FirDeclarationGenerationExtension` in this Kotlin version; it does not affect correctness, only IC speed.

## Limitations

- Only top-level `@Aspect` classes are fully supported. Nested aspects (`com.example.Outer.Inner`) fall back to a one-level-deep nested-class heuristic that isn't well-tested.

## Test plan

- [x] `./gradlew :aspectk-compiler:compileKotlin` passes
- [x] `:test:compileKotlinJvm` produces the expected `Ref_<hex>` marker classes under `com.github.kitakkun.aspectk.generated.refs` (verified by `find test/build/classes -name 'Ref_*'`)
- [ ] Wire up a separate library module containing `@Aspect` classes, consume it from `test/`, and verify the advice fires (deferred — needs a second sample module)
