### PR TITLE
Adopt official Kotlin compiler test framework

### DIFF
--- a/aspectk-compiler/.gitignore
+++ b/aspectk-compiler/.gitignore
@@ -1,0 +1,1 @@
+test-gen/

--- a/aspectk-compiler/build.gradle.kts
+++ b/aspectk-compiler/build.gradle.kts
@@ -2,17 +2,94 @@ plugins {
     alias(libs.plugins.aspectkCommon)
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.ksp)
+    `java-test-fixtures`
     `maven-publish`
 }
+
+val testArtifacts: Configuration by configurations.creating
 
 dependencies {
     implementation(project(":aspectk-plugin-common"))
     implementation(project(":aspectk-expression"))
-    implementation(libs.kotlin.compiler.embeddable)
+    compileOnly(libs.kotlin.compiler)
     compileOnly(libs.auto.service)
     ksp(libs.auto.service.ksp)
 
-    testImplementation(kotlin("test"))
+    testFixturesApi(libs.kotlin.test.junit5)
+    testFixturesApi(libs.kotlin.compiler.internal.test.framework)
+    testFixturesApi(libs.kotlin.compiler)
+    testFixturesRuntimeOnly(libs.junit4)
+
+    // Resolved into Test-runtime system properties so the test framework can locate
+    // stdlib / reflect / test jars by absolute path.
+    testArtifacts(libs.kotlin.stdlib)
+    testArtifacts(libs.kotlin.stdlib.jdk8)
+    testArtifacts(libs.kotlin.reflect)
+    testArtifacts(libs.kotlin.test)
+    testArtifacts(libs.kotlin.script.runtime)
+    testArtifacts(libs.kotlin.annotations.jvm)
+}
+
+sourceSets {
+    test {
+        java.setSrcDirs(listOf("test", "test-gen"))
+        resources.setSrcDirs(listOf("testData"))
+    }
+    testFixtures {
+        java.setSrcDirs(listOf("test-fixtures"))
+    }
+}
+
+fun Test.setLibraryProperty(propName: String, jarName: String) {
+    val path = testArtifacts.files
+        .find { """$jarName-\d.*""".toRegex().matches(it.name) }
+        ?.absolutePath
+        ?: return
+    systemProperty(propName, path)
+}
+
+tasks.test {
+    dependsOn(testArtifacts)
+    dependsOn(":aspectk-annotations:jvmJar")
+    dependsOn(":aspectk-core:jvmJar")
+
+    useJUnitPlatform()
+    workingDir = rootDir
+
+    systemProperty("idea.home.path", rootDir)
+    systemProperty("idea.ignore.disabled.plugins", "true")
+
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-stdlib", "kotlin-stdlib")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-stdlib-jdk8", "kotlin-stdlib-jdk8")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-reflect", "kotlin-reflect")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-test", "kotlin-test")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-script-runtime", "kotlin-script-runtime")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-annotations-jvm", "kotlin-annotations-jvm")
+
+    val annotationsJar = rootProject.layout.projectDirectory
+        .dir("aspectk-annotations/build/libs")
+        .asFileTree.matching { include("aspectk-annotations-jvm-*.jar") }
+    val coreJar = rootProject.layout.projectDirectory
+        .dir("aspectk-core/build/libs")
+        .asFileTree.matching { include("aspectk-core-jvm-*.jar") }
+    doFirst {
+        systemProperty("aspectk.annotations.jar", annotationsJar.singleFile.absolutePath)
+        systemProperty("aspectk.core.jar", coreJar.singleFile.absolutePath)
+    }
+}
+
+val generateTests by tasks.registering(JavaExec::class) {
+    inputs.dir(layout.projectDirectory.dir("testData"))
+    outputs.dir(layout.projectDirectory.dir("test-gen"))
+    classpath = sourceSets.testFixtures.get().runtimeClasspath
+    mainClass.set("com.github.kitakkun.aspectk.compiler.test.GenerateTestsKt")
+    workingDir = rootDir
+}
+tasks.compileTestKotlin { dependsOn(generateTests) }
+tasks.matching {
+    it.name == "kspTestKotlin" || it.name == "compileTestJava"
+}.configureEach {
+    dependsOn(generateTests)
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/GenerateTests.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/GenerateTests.kt
@@ -1,0 +1,18 @@
+package com.github.kitakkun.aspectk.compiler.test
+
+import com.github.kitakkun.aspectk.compiler.test.runners.AbstractAspectKBoxTest
+import com.github.kitakkun.aspectk.compiler.test.runners.AbstractAspectKDiagnosticTest
+import org.jetbrains.kotlin.generators.generateTestGroupSuiteWithJUnit5
+
+fun main() {
+    generateTestGroupSuiteWithJUnit5 {
+        testGroup(testDataRoot = "aspectk-compiler/testData", testsRoot = "aspectk-compiler/test-gen") {
+            testClass<AbstractAspectKDiagnosticTest> {
+                model("diagnostics")
+            }
+            testClass<AbstractAspectKBoxTest> {
+                model("box")
+            }
+        }
+    }
+}

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/runners/AbstractAspectKBoxTest.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/runners/AbstractAspectKBoxTest.kt
@@ -1,0 +1,31 @@
+package com.github.kitakkun.aspectk.compiler.test.runners
+
+import com.github.kitakkun.aspectk.compiler.test.services.AspectKClasspathConfigurator
+import com.github.kitakkun.aspectk.compiler.test.services.AspectKRuntimeClasspathProvider
+import com.github.kitakkun.aspectk.compiler.test.services.AspectKStandardLibrariesPathProvider
+import com.github.kitakkun.aspectk.compiler.test.services.ExtensionRegistrarConfigurator
+import org.jetbrains.kotlin.test.FirParser
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
+import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives
+import org.jetbrains.kotlin.test.runners.codegen.AbstractFirBlackBoxCodegenTestBase
+import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
+
+open class AbstractAspectKBoxTest : AbstractFirBlackBoxCodegenTestBase(FirParser.LightTree) {
+    override fun createKotlinStandardLibrariesPathProvider(): KotlinStandardLibrariesPathProvider {
+        return AspectKStandardLibrariesPathProvider
+    }
+
+    override fun configure(builder: TestConfigurationBuilder) {
+        super.configure(builder)
+        with(builder) {
+            defaultDirectives {
+                +CodegenTestDirectives.DUMP_IR
+                +CodegenTestDirectives.IGNORE_DEXING
+                +JvmEnvironmentConfigurationDirectives.FULL_JDK
+            }
+            useConfigurators(::ExtensionRegistrarConfigurator, ::AspectKClasspathConfigurator)
+            useCustomRuntimeClasspathProviders(::AspectKRuntimeClasspathProvider)
+        }
+    }
+}

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/runners/AbstractAspectKDiagnosticTest.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/runners/AbstractAspectKDiagnosticTest.kt
@@ -1,0 +1,30 @@
+package com.github.kitakkun.aspectk.compiler.test.runners
+
+import com.github.kitakkun.aspectk.compiler.test.services.AspectKClasspathConfigurator
+import com.github.kitakkun.aspectk.compiler.test.services.AspectKRuntimeClasspathProvider
+import com.github.kitakkun.aspectk.compiler.test.services.AspectKStandardLibrariesPathProvider
+import com.github.kitakkun.aspectk.compiler.test.services.ExtensionRegistrarConfigurator
+import org.jetbrains.kotlin.test.FirParser
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.FirDiagnosticsDirectives
+import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives
+import org.jetbrains.kotlin.test.runners.AbstractFirDiagnosticTestBase
+import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
+
+open class AbstractAspectKDiagnosticTest : AbstractFirDiagnosticTestBase(FirParser.LightTree) {
+    override fun createKotlinStandardLibrariesPathProvider(): KotlinStandardLibrariesPathProvider {
+        return AspectKStandardLibrariesPathProvider
+    }
+
+    override fun configure(builder: TestConfigurationBuilder) {
+        super.configure(builder)
+        with(builder) {
+            defaultDirectives {
+                +FirDiagnosticsDirectives.FIR_DUMP
+                +JvmEnvironmentConfigurationDirectives.FULL_JDK
+            }
+            useConfigurators(::ExtensionRegistrarConfigurator, ::AspectKClasspathConfigurator)
+            useCustomRuntimeClasspathProviders(::AspectKRuntimeClasspathProvider)
+        }
+    }
+}

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/AspectKClasspathConfigurator.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/AspectKClasspathConfigurator.kt
@@ -1,0 +1,27 @@
+package com.github.kitakkun.aspectk.compiler.test.services
+
+import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoot
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.EnvironmentConfigurator
+import org.jetbrains.kotlin.test.services.TestServices
+import java.io.File
+
+/**
+ * Adds the `aspectk-annotations` and `aspectk-core` jars to the compilation classpath
+ * of every test, so test data files can `import com.github.kitakkun.aspectk.annotations.*`
+ * and refer to `@Aspect`, `JoinPoint`, etc.
+ *
+ * The jar paths are passed in by Gradle via system properties (see
+ * `aspectk-compiler/build.gradle.kts` → `tasks.test`).
+ */
+class AspectKClasspathConfigurator(testServices: TestServices) : EnvironmentConfigurator(testServices) {
+    override fun configureCompilerConfiguration(configuration: CompilerConfiguration, module: TestModule) {
+        val annotations = System.getProperty("aspectk.annotations.jar")
+            ?: error("System property `aspectk.annotations.jar` is not set")
+        val core = System.getProperty("aspectk.core.jar")
+            ?: error("System property `aspectk.core.jar` is not set")
+        configuration.addJvmClasspathRoot(File(annotations))
+        configuration.addJvmClasspathRoot(File(core))
+    }
+}

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/AspectKRuntimeClasspathProvider.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/AspectKRuntimeClasspathProvider.kt
@@ -1,0 +1,23 @@
+package com.github.kitakkun.aspectk.compiler.test.services
+
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.RuntimeClasspathProvider
+import org.jetbrains.kotlin.test.services.TestServices
+import java.io.File
+
+/**
+ * Makes the `aspectk-annotations` and `aspectk-core` runtime jars available to
+ * compiled test data, so test sources can `import com.github.kitakkun.aspectk.annotations.*`
+ * and `import com.github.kitakkun.aspectk.core.*`.
+ *
+ * Jar paths are passed by Gradle via system properties (see aspectk-compiler/build.gradle.kts).
+ */
+class AspectKRuntimeClasspathProvider(testServices: TestServices) : RuntimeClasspathProvider(testServices) {
+    override fun runtimeClassPaths(module: TestModule): List<File> {
+        val annotations = System.getProperty("aspectk.annotations.jar")
+            ?: error("System property `aspectk.annotations.jar` is not set; check aspectk-compiler/build.gradle.kts tasks.test wiring")
+        val core = System.getProperty("aspectk.core.jar")
+            ?: error("System property `aspectk.core.jar` is not set; check aspectk-compiler/build.gradle.kts tasks.test wiring")
+        return listOf(File(annotations), File(core))
+    }
+}

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/AspectKStandardLibrariesPathProvider.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/AspectKStandardLibrariesPathProvider.kt
@@ -1,0 +1,26 @@
+package com.github.kitakkun.aspectk.compiler.test.services
+
+import org.jetbrains.kotlin.test.services.EnvironmentBasedStandardLibrariesPathProvider
+import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
+import java.io.File
+
+/**
+ * Wraps [EnvironmentBasedStandardLibrariesPathProvider] but redirects the "minimal"
+ * runtime jar to the full one, since `dist/kotlin-stdlib-jvm-minimal-for-test.jar`
+ * only exists inside the JetBrains Kotlin compiler monorepo.
+ */
+object AspectKStandardLibrariesPathProvider : KotlinStandardLibrariesPathProvider() {
+    private val delegate = EnvironmentBasedStandardLibrariesPathProvider
+
+    override fun runtimeJarForTests(): File = delegate.runtimeJarForTests()
+    override fun runtimeJarForTestsWithJdk8(): File = delegate.runtimeJarForTestsWithJdk8()
+    override fun minimalRuntimeJarForTests(): File = delegate.runtimeJarForTests()
+    override fun reflectJarForTests(): File = delegate.reflectJarForTests()
+    override fun kotlinTestJarForTests(): File = delegate.kotlinTestJarForTests()
+    override fun scriptRuntimeJarForTests(): File = delegate.scriptRuntimeJarForTests()
+    override fun jvmAnnotationsForTests(): File = delegate.jvmAnnotationsForTests()
+    override fun getAnnotationsJar(): File = delegate.getAnnotationsJar()
+    override fun fullJsStdlib(): File = delegate.fullJsStdlib()
+    override fun defaultJsStdlib(): File = delegate.defaultJsStdlib()
+    override fun kotlinTestJsKLib(): File = delegate.kotlinTestJsKLib()
+}

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/ExtensionRegistrarConfigurator.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/ExtensionRegistrarConfigurator.kt
@@ -1,0 +1,26 @@
+package com.github.kitakkun.aspectk.compiler.test.services
+
+import com.github.kitakkun.aspectk.compiler.backend.AspectKIrGenerationExtension
+import com.github.kitakkun.aspectk.compiler.fir.AspectKFirExtensionRegistrar
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.EnvironmentConfigurator
+import org.jetbrains.kotlin.test.services.TestServices
+
+@OptIn(ExperimentalCompilerApi::class)
+class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentConfigurator(testServices) {
+    override fun CompilerPluginRegistrar.ExtensionStorage.registerCompilerExtensions(
+        module: TestModule,
+        configuration: CompilerConfiguration,
+    ) {
+        val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+        FirExtensionRegistrarAdapter.registerExtension(AspectKFirExtensionRegistrar())
+        IrGenerationExtension.registerExtension(AspectKIrGenerationExtension(messageCollector))
+    }
+}

--- a/aspectk-compiler/test-fixtures/com/intellij/openapi/util/io/NioFiles.kt
+++ b/aspectk-compiler/test-fixtures/com/intellij/openapi/util/io/NioFiles.kt
@@ -1,0 +1,57 @@
+@file:JvmName("NioFiles")
+
+package com.intellij.openapi.util.io
+
+import java.io.IOException
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.PosixFilePermission
+
+/**
+ * **TEST-ONLY shim**.
+ *
+ * `kotlin-compiler-internal-test-framework:1.9.22` calls
+ * [com.intellij.openapi.util.io.NioFiles.deleteRecursively] (Path overload),
+ * but the [NioFiles] class shipped inside `kotlin-compiler:1.9.22.jar` only provides
+ * [createDirectories] and [setExecutable] — no `deleteRecursively`. This is an
+ * upstream packaging mismatch in the published 1.9.22 artifacts.
+ *
+ * This file declares a same-FQN replacement with all three methods. Because the
+ * test-fixtures classpath entry appears before the kotlin-compiler jar in Gradle's
+ * test runtime classpath, the JVM resolves [NioFiles] to this class and the
+ * original is shadowed. Drop this file once we move off Kotlin 1.9.22.
+ */
+
+@Throws(IOException::class)
+public fun createDirectories(path: Path): Path = Files.createDirectories(path)
+
+@Throws(IOException::class)
+public fun setExecutable(path: Path) {
+    val perms = Files.getPosixFilePermissions(path).toMutableSet()
+    perms.add(PosixFilePermission.OWNER_EXECUTE)
+    perms.add(PosixFilePermission.GROUP_EXECUTE)
+    perms.add(PosixFilePermission.OTHERS_EXECUTE)
+    Files.setPosixFilePermissions(path, perms)
+}
+
+@Throws(IOException::class)
+public fun deleteRecursively(path: Path) {
+    if (!Files.exists(path)) return
+    Files.walkFileTree(
+        path,
+        object : SimpleFileVisitor<Path>() {
+            override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+                Files.deleteIfExists(file)
+                return FileVisitResult.CONTINUE
+            }
+            override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
+                if (exc != null) throw exc
+                Files.deleteIfExists(dir)
+                return FileVisitResult.CONTINUE
+            }
+        },
+    )
+}

--- a/aspectk-compiler/testData/box/afterAdvice.fir.ir.txt
+++ b/aspectk-compiler/testData/box/afterAdvice.fir.ir.txt
@@ -1,0 +1,83 @@
+FILE fqName:<root> fileName:/afterAdvice.kt
+  PROPERTY name:log visibility:public modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:log type:kotlin.collections.MutableList<kotlin.String> visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun mutableListOf <T> (): kotlin.collections.MutableList<T of kotlin.collections.mutableListOf> declared in kotlin.collections' type=kotlin.collections.MutableList<kotlin.String> origin=null
+          <T>: kotlin.String
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-log> visibility:public modality:FINAL <> () returnType:kotlin.collections.MutableList<kotlin.String>
+      correspondingProperty: PROPERTY name:log visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:log type:kotlin.collections.MutableList<kotlin.String> visibility:private [final,static]' type=kotlin.collections.MutableList<kotlin.String> origin=null
+  CLASS CLASS name:TraceAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.TraceAspect
+    CONSTRUCTOR visibility:public <> () returnType:<root>.TraceAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:TraceAspect modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN name:afterTarget visibility:public modality:FINAL <> ($this:<root>.TraceAspect) returnType:kotlin.Unit
+      annotations:
+        After(pointcut = 'execution(public target())')
+      $this: VALUE_PARAMETER name:<this> type:<root>.TraceAspect
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          CALL 'public abstract fun add (element: E of kotlin.collections.MutableList): kotlin.Boolean declared in kotlin.collections.MutableList' type=kotlin.Boolean origin=null
+            $this: CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+            element: CONST String type=kotlin.String value="after"
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  FUN name:target visibility:public modality:FINAL <> () returnType:kotlin.Unit
+    BLOCK_BODY
+      VAR name:tmp0 type:<root>.TraceAspect [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.TraceAspect' type=<root>.TraceAspect origin=null
+      VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:com.github.kitakkun.aspectk.core.StaticJoinPoint [val]
+        CONSTRUCTOR_CALL 'public constructor <init> (dispatchReceiver: com.github.kitakkun.aspectk.core.JoinPointArgument?, extensionReceiver: com.github.kitakkun.aspectk.core.JoinPointArgument?, contextArguments: kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument>, valueArguments: kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument>, methodName: kotlin.String, targetClassName: kotlin.String, signature: kotlin.String) declared in com.github.kitakkun.aspectk.core.StaticJoinPoint' type=com.github.kitakkun.aspectk.core.StaticJoinPoint origin=null
+          dispatchReceiver: CONST Null type=kotlin.Nothing? value=null
+          extensionReceiver: CONST Null type=kotlin.Nothing? value=null
+          contextArguments: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<T of kotlin.collections.listOf> origin=null
+            <T>: <none>
+            elements: VARARG type=kotlin.Array<com.github.kitakkun.aspectk.core.JoinPointArgument> varargElementType=com.github.kitakkun.aspectk.core.JoinPointArgument
+          valueArguments: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<T of kotlin.collections.listOf> origin=null
+            <T>: <none>
+            elements: VARARG type=kotlin.Array<com.github.kitakkun.aspectk.core.JoinPointArgument> varargElementType=com.github.kitakkun.aspectk.core.JoinPointArgument
+          methodName: CONST String type=kotlin.String value="target"
+          targetClassName: CONST String type=kotlin.String value=""
+          signature: CONST String type=kotlin.String value="target(): kotlin.Unit"
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public abstract fun add (element: E of kotlin.collections.MutableList): kotlin.Boolean declared in kotlin.collections.MutableList' type=kotlin.Boolean origin=null
+          $this: CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+          element: CONST String type=kotlin.String value="body"
+      CALL 'public final fun afterTarget (): kotlin.Unit declared in <root>.TraceAspect' type=kotlin.Unit origin=null
+        $this: GET_VAR 'val tmp0: <root>.TraceAspect declared in <root>.target' type=<root>.TraceAspect origin=null
+  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun target (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              arg0: CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+              arg1: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<kotlin.String> origin=null
+                <T>: kotlin.String
+                elements: VARARG type=kotlin.Array<out kotlin.String> varargElementType=kotlin.String
+                  CONST String type=kotlin.String value="body"
+                  CONST String type=kotlin.String value="after"
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: "
+              CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY

--- a/aspectk-compiler/testData/box/afterAdvice.kt
+++ b/aspectk-compiler/testData/box/afterAdvice.kt
@@ -1,0 +1,21 @@
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.After
+
+val log = mutableListOf<String>()
+
+@Aspect
+class TraceAspect {
+    @After("execution(public target())")
+    fun afterTarget() {
+        log.add("after")
+    }
+}
+
+fun target() {
+    log.add("body")
+}
+
+fun box(): String {
+    target()
+    return if (log == listOf("body", "after")) "OK" else "FAIL: $log"
+}

--- a/aspectk-compiler/testData/box/aroundAdvice.fir.ir.txt
+++ b/aspectk-compiler/testData/box/aroundAdvice.fir.ir.txt
@@ -1,0 +1,100 @@
+FILE fqName:<root> fileName:/aroundAdvice.kt
+  PROPERTY name:log visibility:public modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:log type:kotlin.collections.MutableList<kotlin.String> visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun mutableListOf <T> (): kotlin.collections.MutableList<T of kotlin.collections.mutableListOf> declared in kotlin.collections' type=kotlin.collections.MutableList<kotlin.String> origin=null
+          <T>: kotlin.String
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-log> visibility:public modality:FINAL <> () returnType:kotlin.collections.MutableList<kotlin.String>
+      correspondingProperty: PROPERTY name:log visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:log type:kotlin.collections.MutableList<kotlin.String> visibility:private [final,static]' type=kotlin.collections.MutableList<kotlin.String> origin=null
+  CLASS CLASS name:TraceAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.TraceAspect
+    CONSTRUCTOR visibility:public <> () returnType:<root>.TraceAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:TraceAspect modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN name:aroundTarget visibility:public modality:FINAL <> ($this:<root>.TraceAspect, pjp:com.github.kitakkun.aspectk.core.ProceedingJoinPoint) returnType:kotlin.Any?
+      annotations:
+        Around(pointcut = 'execution(public target())')
+      $this: VALUE_PARAMETER name:<this> type:<root>.TraceAspect
+      VALUE_PARAMETER name:pjp index:0 type:com.github.kitakkun.aspectk.core.ProceedingJoinPoint
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          CALL 'public abstract fun add (element: E of kotlin.collections.MutableList): kotlin.Boolean declared in kotlin.collections.MutableList' type=kotlin.Boolean origin=null
+            $this: CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+            element: CONST String type=kotlin.String value="around-before"
+        VAR name:result type:kotlin.Any? [val]
+          CALL 'public final fun proceed (): kotlin.Any? declared in com.github.kitakkun.aspectk.core.ProceedingJoinPoint' type=kotlin.Any? origin=null
+            $this: GET_VAR 'pjp: com.github.kitakkun.aspectk.core.ProceedingJoinPoint declared in <root>.TraceAspect.aroundTarget' type=com.github.kitakkun.aspectk.core.ProceedingJoinPoint origin=null
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          CALL 'public abstract fun add (element: E of kotlin.collections.MutableList): kotlin.Boolean declared in kotlin.collections.MutableList' type=kotlin.Boolean origin=null
+            $this: CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+            element: CONST String type=kotlin.String value="around-after"
+        RETURN type=kotlin.Nothing from='public final fun aroundTarget (pjp: com.github.kitakkun.aspectk.core.ProceedingJoinPoint): kotlin.Any? declared in <root>.TraceAspect'
+          GET_VAR 'val result: kotlin.Any? declared in <root>.TraceAspect.aroundTarget' type=kotlin.Any? origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  FUN name:target visibility:public modality:FINAL <> () returnType:kotlin.Unit
+    BLOCK_BODY
+      VAR name:tmp0 type:<root>.TraceAspect [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.TraceAspect' type=<root>.TraceAspect origin=null
+      VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:com.github.kitakkun.aspectk.core.ProceedingJoinPoint [val]
+        CONSTRUCTOR_CALL 'public constructor <init> (dispatchReceiver: com.github.kitakkun.aspectk.core.JoinPointArgument?, extensionReceiver: com.github.kitakkun.aspectk.core.JoinPointArgument?, contextArguments: kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument>, valueArguments: kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument>, methodName: kotlin.String, targetClassName: kotlin.String, signature: kotlin.String, proceedFn: kotlin.Function0<kotlin.Any?>) declared in com.github.kitakkun.aspectk.core.ProceedingJoinPoint' type=com.github.kitakkun.aspectk.core.ProceedingJoinPoint origin=null
+          dispatchReceiver: CONST Null type=kotlin.Nothing? value=null
+          extensionReceiver: CONST Null type=kotlin.Nothing? value=null
+          contextArguments: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<T of kotlin.collections.listOf> origin=null
+            <T>: <none>
+            elements: VARARG type=kotlin.Array<com.github.kitakkun.aspectk.core.JoinPointArgument> varargElementType=com.github.kitakkun.aspectk.core.JoinPointArgument
+          valueArguments: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<T of kotlin.collections.listOf> origin=null
+            <T>: <none>
+            elements: VARARG type=kotlin.Array<com.github.kitakkun.aspectk.core.JoinPointArgument> varargElementType=com.github.kitakkun.aspectk.core.JoinPointArgument
+          methodName: CONST String type=kotlin.String value="target"
+          targetClassName: CONST String type=kotlin.String value=""
+          signature: CONST String type=kotlin.String value="target(): kotlin.Unit"
+          proceedFn: FUN_EXPR type=kotlin.Function0<kotlin.Any?> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<no name provided> visibility:local modality:FINAL <> () returnType:kotlin.Any?
+              BLOCK_BODY
+                TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                  CALL 'public abstract fun add (element: E of kotlin.collections.MutableList): kotlin.Boolean declared in kotlin.collections.MutableList' type=kotlin.Boolean origin=null
+                    $this: CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+                    element: CONST String type=kotlin.String value="body"
+                RETURN type=kotlin.Nothing from='local final fun <no name provided> (): kotlin.Any? declared in <root>.target'
+                  GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+      CALL 'public final fun aroundTarget (pjp: com.github.kitakkun.aspectk.core.ProceedingJoinPoint): kotlin.Any? declared in <root>.TraceAspect' type=kotlin.Any? origin=null
+        $this: GET_VAR 'val tmp0: <root>.TraceAspect declared in <root>.target' type=<root>.TraceAspect origin=null
+        pjp: GET_VAR 'val tmp_0: com.github.kitakkun.aspectk.core.ProceedingJoinPoint declared in <root>.target' type=com.github.kitakkun.aspectk.core.ProceedingJoinPoint origin=null
+  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun target (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              arg0: CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+              arg1: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<kotlin.String> origin=null
+                <T>: kotlin.String
+                elements: VARARG type=kotlin.Array<out kotlin.String> varargElementType=kotlin.String
+                  CONST String type=kotlin.String value="around-before"
+                  CONST String type=kotlin.String value="body"
+                  CONST String type=kotlin.String value="around-after"
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: "
+              CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY

--- a/aspectk-compiler/testData/box/aroundAdvice.kt
+++ b/aspectk-compiler/testData/box/aroundAdvice.kt
@@ -1,0 +1,25 @@
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Around
+import com.github.kitakkun.aspectk.core.ProceedingJoinPoint
+
+val log = mutableListOf<String>()
+
+@Aspect
+class TraceAspect {
+    @Around("execution(public target())")
+    fun aroundTarget(pjp: ProceedingJoinPoint): Any? {
+        log.add("around-before")
+        val result = pjp.proceed()
+        log.add("around-after")
+        return result
+    }
+}
+
+fun target() {
+    log.add("body")
+}
+
+fun box(): String {
+    target()
+    return if (log == listOf("around-before", "body", "around-after")) "OK" else "FAIL: $log"
+}

--- a/aspectk-compiler/testData/box/beforeAdvice.fir.ir.txt
+++ b/aspectk-compiler/testData/box/beforeAdvice.fir.ir.txt
@@ -1,0 +1,83 @@
+FILE fqName:<root> fileName:/beforeAdvice.kt
+  PROPERTY name:log visibility:public modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:log type:kotlin.collections.MutableList<kotlin.String> visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun mutableListOf <T> (): kotlin.collections.MutableList<T of kotlin.collections.mutableListOf> declared in kotlin.collections' type=kotlin.collections.MutableList<kotlin.String> origin=null
+          <T>: kotlin.String
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-log> visibility:public modality:FINAL <> () returnType:kotlin.collections.MutableList<kotlin.String>
+      correspondingProperty: PROPERTY name:log visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:log type:kotlin.collections.MutableList<kotlin.String> visibility:private [final,static]' type=kotlin.collections.MutableList<kotlin.String> origin=null
+  CLASS CLASS name:TraceAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.TraceAspect
+    CONSTRUCTOR visibility:public <> () returnType:<root>.TraceAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:TraceAspect modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN name:beforeTarget visibility:public modality:FINAL <> ($this:<root>.TraceAspect) returnType:kotlin.Unit
+      annotations:
+        Before(pointcut = 'execution(public target())')
+      $this: VALUE_PARAMETER name:<this> type:<root>.TraceAspect
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          CALL 'public abstract fun add (element: E of kotlin.collections.MutableList): kotlin.Boolean declared in kotlin.collections.MutableList' type=kotlin.Boolean origin=null
+            $this: CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+            element: CONST String type=kotlin.String value="before"
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  FUN name:target visibility:public modality:FINAL <> () returnType:kotlin.Unit
+    BLOCK_BODY
+      VAR name:tmp0 type:<root>.TraceAspect [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.TraceAspect' type=<root>.TraceAspect origin=null
+      VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:com.github.kitakkun.aspectk.core.StaticJoinPoint [val]
+        CONSTRUCTOR_CALL 'public constructor <init> (dispatchReceiver: com.github.kitakkun.aspectk.core.JoinPointArgument?, extensionReceiver: com.github.kitakkun.aspectk.core.JoinPointArgument?, contextArguments: kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument>, valueArguments: kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument>, methodName: kotlin.String, targetClassName: kotlin.String, signature: kotlin.String) declared in com.github.kitakkun.aspectk.core.StaticJoinPoint' type=com.github.kitakkun.aspectk.core.StaticJoinPoint origin=null
+          dispatchReceiver: CONST Null type=kotlin.Nothing? value=null
+          extensionReceiver: CONST Null type=kotlin.Nothing? value=null
+          contextArguments: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<T of kotlin.collections.listOf> origin=null
+            <T>: <none>
+            elements: VARARG type=kotlin.Array<com.github.kitakkun.aspectk.core.JoinPointArgument> varargElementType=com.github.kitakkun.aspectk.core.JoinPointArgument
+          valueArguments: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<T of kotlin.collections.listOf> origin=null
+            <T>: <none>
+            elements: VARARG type=kotlin.Array<com.github.kitakkun.aspectk.core.JoinPointArgument> varargElementType=com.github.kitakkun.aspectk.core.JoinPointArgument
+          methodName: CONST String type=kotlin.String value="target"
+          targetClassName: CONST String type=kotlin.String value=""
+          signature: CONST String type=kotlin.String value="target(): kotlin.Unit"
+      CALL 'public final fun beforeTarget (): kotlin.Unit declared in <root>.TraceAspect' type=kotlin.Unit origin=null
+        $this: GET_VAR 'val tmp0: <root>.TraceAspect declared in <root>.target' type=<root>.TraceAspect origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public abstract fun add (element: E of kotlin.collections.MutableList): kotlin.Boolean declared in kotlin.collections.MutableList' type=kotlin.Boolean origin=null
+          $this: CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+          element: CONST String type=kotlin.String value="body"
+  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun target (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              arg0: CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY
+              arg1: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<kotlin.String> origin=null
+                <T>: kotlin.String
+                elements: VARARG type=kotlin.Array<out kotlin.String> varargElementType=kotlin.String
+                  CONST String type=kotlin.String value="before"
+                  CONST String type=kotlin.String value="body"
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: "
+              CALL 'public final fun <get-log> (): kotlin.collections.MutableList<kotlin.String> declared in <root>' type=kotlin.collections.MutableList<kotlin.String> origin=GET_PROPERTY

--- a/aspectk-compiler/testData/box/beforeAdvice.kt
+++ b/aspectk-compiler/testData/box/beforeAdvice.kt
@@ -1,0 +1,21 @@
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+
+val log = mutableListOf<String>()
+
+@Aspect
+class TraceAspect {
+    @Before("execution(public target())")
+    fun beforeTarget() {
+        log.add("before")
+    }
+}
+
+fun target() {
+    log.add("body")
+}
+
+fun box(): String {
+    target()
+    return if (log == listOf("before", "body")) "OK" else "FAIL: $log"
+}

--- a/aspectk-compiler/testData/box/joinPointFields.fir.ir.txt
+++ b/aspectk-compiler/testData/box/joinPointFields.fir.ir.txt
@@ -1,0 +1,212 @@
+FILE fqName:<root> fileName:/joinPointFields.kt
+  PROPERTY name:capturedMethodName visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:capturedMethodName type:kotlin.String visibility:private [static]
+      EXPRESSION_BODY
+        CONST String type=kotlin.String value=""
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-capturedMethodName> visibility:public modality:FINAL <> () returnType:kotlin.String
+      correspondingProperty: PROPERTY name:capturedMethodName visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-capturedMethodName> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:capturedMethodName type:kotlin.String visibility:private [static]' type=kotlin.String origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-capturedMethodName> visibility:public modality:FINAL <> (<set-?>:kotlin.String) returnType:kotlin.Unit
+      correspondingProperty: PROPERTY name:capturedMethodName visibility:public modality:FINAL [var]
+      VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:capturedMethodName type:kotlin.String visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.String declared in <root>.<set-capturedMethodName>' type=kotlin.String origin=null
+  PROPERTY name:capturedFirstArgName visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:capturedFirstArgName type:kotlin.String visibility:private [static]
+      EXPRESSION_BODY
+        CONST String type=kotlin.String value=""
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-capturedFirstArgName> visibility:public modality:FINAL <> () returnType:kotlin.String
+      correspondingProperty: PROPERTY name:capturedFirstArgName visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-capturedFirstArgName> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:capturedFirstArgName type:kotlin.String visibility:private [static]' type=kotlin.String origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-capturedFirstArgName> visibility:public modality:FINAL <> (<set-?>:kotlin.String) returnType:kotlin.Unit
+      correspondingProperty: PROPERTY name:capturedFirstArgName visibility:public modality:FINAL [var]
+      VALUE_PARAMETER name:<set-?> index:0 type:kotlin.String
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:capturedFirstArgName type:kotlin.String visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.String declared in <root>.<set-capturedFirstArgName>' type=kotlin.String origin=null
+  PROPERTY name:capturedFirstArgValue visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:capturedFirstArgValue type:kotlin.Any? visibility:private [static]
+      EXPRESSION_BODY
+        CONST Null type=kotlin.Nothing? value=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-capturedFirstArgValue> visibility:public modality:FINAL <> () returnType:kotlin.Any?
+      correspondingProperty: PROPERTY name:capturedFirstArgValue visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-capturedFirstArgValue> (): kotlin.Any? declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:capturedFirstArgValue type:kotlin.Any? visibility:private [static]' type=kotlin.Any? origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-capturedFirstArgValue> visibility:public modality:FINAL <> (<set-?>:kotlin.Any?) returnType:kotlin.Unit
+      correspondingProperty: PROPERTY name:capturedFirstArgValue visibility:public modality:FINAL [var]
+      VALUE_PARAMETER name:<set-?> index:0 type:kotlin.Any?
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:capturedFirstArgValue type:kotlin.Any? visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.Any? declared in <root>.<set-capturedFirstArgValue>' type=kotlin.Any? origin=null
+  CLASS CLASS name:CapturingAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.CapturingAspect
+    CONSTRUCTOR visibility:public <> () returnType:<root>.CapturingAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:CapturingAspect modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN name:captureJoinPoint visibility:public modality:FINAL <> ($this:<root>.CapturingAspect, jp:com.github.kitakkun.aspectk.core.JoinPoint) returnType:kotlin.Unit
+      annotations:
+        Before(pointcut = 'execution(public Target.greet(*))')
+      $this: VALUE_PARAMETER name:<this> type:<root>.CapturingAspect
+      VALUE_PARAMETER name:jp index:0 type:com.github.kitakkun.aspectk.core.JoinPoint
+      BLOCK_BODY
+        CALL 'public final fun <set-capturedMethodName> (<set-?>: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+          <set-?>: CALL 'public final fun <get-methodName> (): kotlin.String declared in com.github.kitakkun.aspectk.core.JoinPoint' type=kotlin.String origin=GET_PROPERTY
+            $this: GET_VAR 'jp: com.github.kitakkun.aspectk.core.JoinPoint declared in <root>.CapturingAspect.captureJoinPoint' type=com.github.kitakkun.aspectk.core.JoinPoint origin=null
+        CALL 'public final fun <set-capturedFirstArgName> (<set-?>: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+          <set-?>: BLOCK type=kotlin.String origin=ELVIS
+            VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.String? [val]
+              BLOCK type=kotlin.String? origin=SAFE_CALL
+                VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:com.github.kitakkun.aspectk.core.JoinPointArgument? [val]
+                  CALL 'public final fun firstOrNull <T> (): T of kotlin.collections.firstOrNull? declared in kotlin.collections' type=com.github.kitakkun.aspectk.core.JoinPointArgument? origin=null
+                    <T>: com.github.kitakkun.aspectk.core.JoinPointArgument
+                    $receiver: CALL 'public final fun <get-valueArguments> (): kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument> declared in com.github.kitakkun.aspectk.core.JoinPoint' type=kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument> origin=GET_PROPERTY
+                      $this: GET_VAR 'jp: com.github.kitakkun.aspectk.core.JoinPoint declared in <root>.CapturingAspect.captureJoinPoint' type=com.github.kitakkun.aspectk.core.JoinPoint origin=null
+                WHEN type=kotlin.String? origin=null
+                  BRANCH
+                    if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                      arg0: GET_VAR 'val tmp_1: com.github.kitakkun.aspectk.core.JoinPointArgument? declared in <root>.CapturingAspect.captureJoinPoint' type=com.github.kitakkun.aspectk.core.JoinPointArgument? origin=null
+                      arg1: CONST Null type=kotlin.Nothing? value=null
+                    then: CONST Null type=kotlin.Nothing? value=null
+                  BRANCH
+                    if: CONST Boolean type=kotlin.Boolean value=true
+                    then: CALL 'public final fun <get-name> (): kotlin.String declared in com.github.kitakkun.aspectk.core.JoinPointArgument' type=kotlin.String origin=GET_PROPERTY
+                      $this: GET_VAR 'val tmp_1: com.github.kitakkun.aspectk.core.JoinPointArgument? declared in <root>.CapturingAspect.captureJoinPoint' type=com.github.kitakkun.aspectk.core.JoinPointArgument? origin=null
+            WHEN type=kotlin.String origin=ELVIS
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp_0: kotlin.String? declared in <root>.CapturingAspect.captureJoinPoint' type=kotlin.String? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: CONST String type=kotlin.String value=""
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: GET_VAR 'val tmp_0: kotlin.String? declared in <root>.CapturingAspect.captureJoinPoint' type=kotlin.String? origin=null
+        CALL 'public final fun <set-capturedFirstArgValue> (<set-?>: kotlin.Any?): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+          <set-?>: BLOCK type=kotlin.Any? origin=SAFE_CALL
+            VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:com.github.kitakkun.aspectk.core.JoinPointArgument? [val]
+              CALL 'public final fun firstOrNull <T> (): T of kotlin.collections.firstOrNull? declared in kotlin.collections' type=com.github.kitakkun.aspectk.core.JoinPointArgument? origin=null
+                <T>: com.github.kitakkun.aspectk.core.JoinPointArgument
+                $receiver: CALL 'public final fun <get-valueArguments> (): kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument> declared in com.github.kitakkun.aspectk.core.JoinPoint' type=kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument> origin=GET_PROPERTY
+                  $this: GET_VAR 'jp: com.github.kitakkun.aspectk.core.JoinPoint declared in <root>.CapturingAspect.captureJoinPoint' type=com.github.kitakkun.aspectk.core.JoinPoint origin=null
+            WHEN type=kotlin.Any? origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  arg0: GET_VAR 'val tmp_2: com.github.kitakkun.aspectk.core.JoinPointArgument? declared in <root>.CapturingAspect.captureJoinPoint' type=com.github.kitakkun.aspectk.core.JoinPointArgument? origin=null
+                  arg1: CONST Null type=kotlin.Nothing? value=null
+                then: CONST Null type=kotlin.Nothing? value=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public final fun <get-value> (): kotlin.Any? declared in com.github.kitakkun.aspectk.core.JoinPointArgument' type=kotlin.Any? origin=GET_PROPERTY
+                  $this: GET_VAR 'val tmp_2: com.github.kitakkun.aspectk.core.JoinPointArgument? declared in <root>.CapturingAspect.captureJoinPoint' type=com.github.kitakkun.aspectk.core.JoinPointArgument? origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:Target modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.Target
+    CONSTRUCTOR visibility:public <> () returnType:<root>.Target [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Target modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN name:greet visibility:public modality:FINAL <> ($this:<root>.Target, name:kotlin.String) returnType:kotlin.Unit
+      $this: VALUE_PARAMETER name:<this> type:<root>.Target
+      VALUE_PARAMETER name:name index:0 type:kotlin.String
+      BLOCK_BODY
+        VAR name:tmp0 type:<root>.CapturingAspect [val]
+          CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.CapturingAspect' type=<root>.CapturingAspect origin=null
+        VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:com.github.kitakkun.aspectk.core.StaticJoinPoint [val]
+          CONSTRUCTOR_CALL 'public constructor <init> (dispatchReceiver: com.github.kitakkun.aspectk.core.JoinPointArgument?, extensionReceiver: com.github.kitakkun.aspectk.core.JoinPointArgument?, contextArguments: kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument>, valueArguments: kotlin.collections.List<com.github.kitakkun.aspectk.core.JoinPointArgument>, methodName: kotlin.String, targetClassName: kotlin.String, signature: kotlin.String) declared in com.github.kitakkun.aspectk.core.StaticJoinPoint' type=com.github.kitakkun.aspectk.core.StaticJoinPoint origin=null
+            dispatchReceiver: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlin.reflect.KClass<*>, value: kotlin.Any?, annotations: kotlin.collections.List<kotlin.Annotation>) declared in com.github.kitakkun.aspectk.core.JoinPointArgument' type=com.github.kitakkun.aspectk.core.JoinPointArgument origin=null
+              name: CONST String type=kotlin.String value="<this>"
+              type: CLASS_REFERENCE 'CLASS CLASS name:Target modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Target>
+              value: GET_VAR '<this>: <root>.Target declared in <root>.Target.greet' type=<root>.Target origin=null
+              annotations: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<T of kotlin.collections.listOf> origin=null
+                <T>: <none>
+                elements: VARARG type=kotlin.Array<kotlin.Annotation> varargElementType=kotlin.Annotation
+            extensionReceiver: CONST Null type=kotlin.Nothing? value=null
+            contextArguments: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<T of kotlin.collections.listOf> origin=null
+              <T>: <none>
+              elements: VARARG type=kotlin.Array<com.github.kitakkun.aspectk.core.JoinPointArgument> varargElementType=com.github.kitakkun.aspectk.core.JoinPointArgument
+            valueArguments: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<T of kotlin.collections.listOf> origin=null
+              <T>: <none>
+              elements: VARARG type=kotlin.Array<com.github.kitakkun.aspectk.core.JoinPointArgument> varargElementType=com.github.kitakkun.aspectk.core.JoinPointArgument
+                CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlin.reflect.KClass<*>, value: kotlin.Any?, annotations: kotlin.collections.List<kotlin.Annotation>) declared in com.github.kitakkun.aspectk.core.JoinPointArgument' type=com.github.kitakkun.aspectk.core.JoinPointArgument origin=null
+                  name: CONST String type=kotlin.String value="name"
+                  type: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+                  value: GET_VAR 'name: kotlin.String declared in <root>.Target.greet' type=kotlin.String origin=null
+                  annotations: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<T of kotlin.collections.listOf> origin=null
+                    <T>: <none>
+                    elements: VARARG type=kotlin.Array<kotlin.Annotation> varargElementType=kotlin.Annotation
+            methodName: CONST String type=kotlin.String value="greet"
+            targetClassName: CONST String type=kotlin.String value="Target"
+            signature: CONST String type=kotlin.String value="Target.greet(kotlin.String): kotlin.Unit"
+        CALL 'public final fun captureJoinPoint (jp: com.github.kitakkun.aspectk.core.JoinPoint): kotlin.Unit declared in <root>.CapturingAspect' type=kotlin.Unit origin=null
+          $this: GET_VAR 'val tmp0: <root>.CapturingAspect declared in <root>.Target.greet' type=<root>.CapturingAspect origin=null
+          jp: GET_VAR 'val tmp_3: com.github.kitakkun.aspectk.core.StaticJoinPoint declared in <root>.Target.greet' type=com.github.kitakkun.aspectk.core.StaticJoinPoint origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun greet (name: kotlin.String): kotlin.Unit declared in <root>.Target' type=kotlin.Unit origin=null
+        $this: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Target' type=<root>.Target origin=null
+        name: CONST String type=kotlin.String value="world"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              arg0: CALL 'public final fun <get-capturedMethodName> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              arg1: CONST String type=kotlin.String value="greet"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: methodName="
+              CALL 'public final fun <get-capturedMethodName> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              arg0: CALL 'public final fun <get-capturedFirstArgName> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              arg1: CONST String type=kotlin.String value="name"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: firstArgName="
+              CALL 'public final fun <get-capturedFirstArgName> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              arg0: CALL 'public final fun <get-capturedFirstArgValue> (): kotlin.Any? declared in <root>' type=kotlin.Any? origin=GET_PROPERTY
+              arg1: CONST String type=kotlin.String value="world"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: firstArgValue="
+              CALL 'public final fun <get-capturedFirstArgValue> (): kotlin.Any? declared in <root>' type=kotlin.Any? origin=GET_PROPERTY
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/joinPointFields.kt
+++ b/aspectk-compiler/testData/box/joinPointFields.kt
@@ -1,0 +1,31 @@
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.core.JoinPoint
+
+var capturedMethodName: String = ""
+var capturedFirstArgName: String = ""
+var capturedFirstArgValue: Any? = null
+
+@Aspect
+class CapturingAspect {
+    @Before("execution(public Target.greet(*))")
+    fun captureJoinPoint(jp: JoinPoint) {
+        capturedMethodName = jp.methodName
+        capturedFirstArgName = jp.valueArguments.firstOrNull()?.name ?: ""
+        capturedFirstArgValue = jp.valueArguments.firstOrNull()?.value
+    }
+}
+
+class Target {
+    fun greet(name: String) {
+        // body intentionally empty; return type Unit so the default-Unit pointcut matches
+    }
+}
+
+fun box(): String {
+    Target().greet("world")
+    if (capturedMethodName != "greet") return "FAIL: methodName=$capturedMethodName"
+    if (capturedFirstArgName != "name") return "FAIL: firstArgName=$capturedFirstArgName"
+    if (capturedFirstArgValue != "world") return "FAIL: firstArgValue=$capturedFirstArgValue"
+    return "OK"
+}

--- a/aspectk-compiler/testData/diagnostics/adviceOutsideAspect.fir.txt
+++ b/aspectk-compiler/testData/diagnostics/adviceOutsideAspect.fir.txt
@@ -1,0 +1,13 @@
+FILE: adviceOutsideAspect.kt
+    public final class NotAnAspect : R|kotlin/Any| {
+        public constructor(): R|NotAnAspect| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|(pointcut = String(execution(public com/example/Foo.bar()))) public final fun beforeAdvice(): R|kotlin/Unit| {
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Pointcut|(expression = String(execution(public com/example/Foo.bar()))) public final fun pointcutDecl(): R|kotlin/Unit| {
+        }
+
+    }

--- a/aspectk-compiler/testData/diagnostics/adviceOutsideAspect.kt
+++ b/aspectk-compiler/testData/diagnostics/adviceOutsideAspect.kt
@@ -1,0 +1,10 @@
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.Pointcut
+
+class NotAnAspect {
+    <!ADVICE_FUNCTION_DECLARATION_SCOPE_VIOLATION!>@Before("execution(public com/example/Foo.bar())")
+    fun beforeAdvice() {}<!>
+
+    <!POINTCUT_FUNCTION_DECLARATION_SCOPE_VIOLATION!>@Pointcut("execution(public com/example/Foo.bar())")
+    fun pointcutDecl() {}<!>
+}

--- a/aspectk-compiler/testData/diagnostics/badAdviceSignature.fir.txt
+++ b/aspectk-compiler/testData/diagnostics/badAdviceSignature.fir.txt
@@ -1,0 +1,13 @@
+FILE: badAdviceSignature.kt
+    @R|com/github/kitakkun/aspectk/annotations/Aspect|() public final class MyAspect : R|kotlin/Any| {
+        public constructor(): R|MyAspect| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|(pointcut = String(args(String))) public final fun beforeOneStringArg(text: R|kotlin/String|): R|kotlin/Unit| {
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/After|(pointcut = String(args(Int, String))) public final fun afterTwoArgs(n: R|kotlin/Int|, text: R|kotlin/String|): R|kotlin/Unit| {
+        }
+
+    }

--- a/aspectk-compiler/testData/diagnostics/badAdviceSignature.kt
+++ b/aspectk-compiler/testData/diagnostics/badAdviceSignature.kt
@@ -1,0 +1,12 @@
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.After
+
+@Aspect
+class MyAspect {
+    <!ADVICE_INVALID_SIGNATURE!>@Before("args(String)")
+    fun beforeOneStringArg(text: String) {}<!>
+
+    <!ADVICE_INVALID_SIGNATURE!>@After("args(Int, String)")
+    fun afterTwoArgs(n: Int, text: String) {}<!>
+}

--- a/aspectk-compiler/testData/diagnostics/emptyAspect.fir.txt
+++ b/aspectk-compiler/testData/diagnostics/emptyAspect.fir.txt
@@ -1,0 +1,7 @@
+FILE: emptyAspect.kt
+    @R|com/github/kitakkun/aspectk/annotations/Aspect|() public final class Empty : R|kotlin/Any| {
+        public constructor(): R|Empty| {
+            super<R|kotlin/Any|>()
+        }
+
+    }

--- a/aspectk-compiler/testData/diagnostics/emptyAspect.kt
+++ b/aspectk-compiler/testData/diagnostics/emptyAspect.kt
@@ -1,0 +1,4 @@
+import com.github.kitakkun.aspectk.annotations.Aspect
+
+<!ASPECT_CLASS_WITH_NO_POINTCUT_OR_ADVICE_ENTRIES!>@Aspect
+class Empty<!>

--- a/aspectk-compiler/testData/diagnostics/emptyPointcut.fir.txt
+++ b/aspectk-compiler/testData/diagnostics/emptyPointcut.fir.txt
@@ -1,0 +1,10 @@
+FILE: emptyPointcut.kt
+    @R|com/github/kitakkun/aspectk/annotations/Aspect|() public final class MyAspect : R|kotlin/Any| {
+        public constructor(): R|MyAspect| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|(pointcut = String()) public final fun before(): R|kotlin/Unit| {
+        }
+
+    }

--- a/aspectk-compiler/testData/diagnostics/emptyPointcut.kt
+++ b/aspectk-compiler/testData/diagnostics/emptyPointcut.kt
@@ -1,0 +1,8 @@
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+
+@Aspect
+class MyAspect {
+    <!EMPTY_POINTCUT_EXPRESSION!>@Before("")
+    fun before() {}<!>
+}

--- a/aspectk-compiler/testData/diagnostics/invalidPointcut.fir.txt
+++ b/aspectk-compiler/testData/diagnostics/invalidPointcut.fir.txt
@@ -1,0 +1,10 @@
+FILE: invalidPointcut.kt
+    @R|com/github/kitakkun/aspectk/annotations/Aspect|() public final class MyAspect : R|kotlin/Any| {
+        public constructor(): R|MyAspect| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|(pointcut = String(garbage()) public final fun before(): R|kotlin/Unit| {
+        }
+
+    }

--- a/aspectk-compiler/testData/diagnostics/invalidPointcut.kt
+++ b/aspectk-compiler/testData/diagnostics/invalidPointcut.kt
@@ -1,0 +1,8 @@
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+
+@Aspect
+class MyAspect {
+    <!INVALID_POINTCUT_EXPRESSION!>@Before("garbage(")
+    fun before() {}<!>
+}

--- a/aspectk-expression/build.gradle.kts
+++ b/aspectk-expression/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.kotlin.compiler.embeddable)
+    compileOnly(libs.kotlin.compiler)
+    testImplementation(libs.kotlin.compiler)
     testImplementation(kotlin("test"))
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,16 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
 
 [libraries]
 kotlin-compiler-embeddable = { group = "org.jetbrains.kotlin", name = "kotlin-compiler-embeddable", version.ref = "kotlin" }
+kotlin-compiler = { group = "org.jetbrains.kotlin", name = "kotlin-compiler", version.ref = "kotlin" }
+kotlin-compiler-internal-test-framework = { group = "org.jetbrains.kotlin", name = "kotlin-compiler-internal-test-framework", version.ref = "kotlin" }
+kotlin-test-junit5 = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit5", version.ref = "kotlin" }
+kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+kotlin-script-runtime = { group = "org.jetbrains.kotlin", name = "kotlin-script-runtime", version.ref = "kotlin" }
+kotlin-annotations-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-annotations-jvm", version.ref = "kotlin" }
+junit4 = { group = "junit", name = "junit", version = "4.13.2" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradle-plugin-api = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin-api", version.ref = "kotlin" }
 auto-service = { group = "com.google.auto.service", name = "auto-service", version.ref = "auto-service" }


### PR DESCRIPTION
## Summary

Adopt JetBrains' `kotlin-compiler-internal-test-framework:1.9.22` so we can regression-test diagnostics and IR transformations against real Kotlin source files, instead of relying on the ad-hoc `test/` sample module + manual `java -cp …` invocations.

## What you can write now

**Diagnostic test** (`aspectk-compiler/testData/diagnostics/emptyAspect.kt`):
```kotlin
import com.github.kitakkun.aspectk.annotations.Aspect

<!ASPECT_CLASS_WITH_NO_POINTCUT_OR_ADVICE_ENTRIES!>@Aspect
class Empty<!>
```

The runner parses the file, strips the `<!…!>…<!>` markers, runs FIR analysis with our extensions registered, re-renders the file with whatever diagnostics actually fired, and compares to the original. A `.fir.txt` golden file is also written for the FIR tree.

**Box test** (`aspectk-compiler/testData/box/beforeAdvice.kt`):
```kotlin
import com.github.kitakkun.aspectk.annotations.Aspect
import com.github.kitakkun.aspectk.annotations.Before

val log = mutableListOf<String>()

@Aspect
class TraceAspect {
    @Before("execution(public target())")
    fun beforeTarget() { log.add("before") }
}

fun target() { log.add("body") }

fun box(): String {
    target()
    return if (log == listOf("before", "body")) "OK" else "FAIL: $log"
}
```

The runner compiles, runs `box()`, and asserts the return value is `"OK"`. A `.fir.ir.txt` golden file dumps the post-transform IR so structural regressions surface immediately.

## Initial coverage

`diagnostics/`:
- `adviceOutsideAspect` — `@Before` / `@Pointcut` outside an `@Aspect` class
- `emptyAspect` — `@Aspect` class with no advice / pointcut entries
- `emptyPointcut` — `@Before("")`
- `invalidPointcut` — `@Before("garbage(")`
- `badAdviceSignature` — `@Before` taking a `String` parameter / two parameters

`box/`:
- `beforeAdvice` — `@Before` fires before the original body
- `afterAdvice` — `@After` fires after the original body
- `aroundAdvice` — `@Around` + `proceed()` wraps the body
- `joinPointFields` — `JoinPoint.methodName`, `valueArguments[0].name/value` are populated correctly

11 tests pass against `develop` (including the framework's `testAllFilesPresent` integrity checks).

## Build wiring

`aspectk-compiler/build.gradle.kts`:
- `compileOnly(libs.kotlin.compiler)` (un-shaded). Mixing the shaded `kotlin-compiler-embeddable` jar with the un-shaded test framework otherwise puts two copies of the IntelliJ-platform classes on the test classpath and crashes with `VerifyError` at startup. `aspectk-expression` follows the same switch for transitive consistency.
- `java-test-fixtures` plugin so test runners live in `test-fixtures/` and can be reused by IDE-driven runs.
- `testArtifacts` configuration resolves `kotlin-stdlib`, `kotlin-reflect`, `kotlin-test`, `kotlin-script-runtime`, `kotlin-annotations-jvm` etc. to absolute paths that are passed to the test framework as `-Dorg.jetbrains.kotlin.test.kotlin-stdlib=…` system properties.
- `aspectk.annotations.jar` / `aspectk.core.jar` are passed the same way; `AspectKClasspathConfigurator` puts them on the test compiler's `JvmClasspathRoots` so test data can `import com.github.kitakkun.aspectk.*`.
- `generateTests` runs `generateTestGroupSuiteWithJUnit5` and emits JUnit 5 wrappers under `aspectk-compiler/test-gen/` (gitignored).

## Two upstream workarounds (test-fixtures only)

1. `AspectKStandardLibrariesPathProvider` overrides `minimalRuntimeJarForTests()` to return the full stdlib — JetBrains' monorepo has `dist/kotlin-stdlib-jvm-minimal-for-test.jar`, but the published artifacts don't.
2. A same-FQN shim of `com.intellij.openapi.util.io.NioFiles` lives in `test-fixtures/` and shadows the one inside `kotlin-compiler:1.9.22.jar`. The published `kotlin-compiler-internal-test-framework:1.9.22` calls `NioFiles.deleteRecursively(Path)` for box-test cleanup, but the `NioFiles` class inside `kotlin-compiler:1.9.22.jar` only provides `createDirectories(Path)` and `setExecutable(Path)` — an upstream packaging mismatch in the 1.9.22 line. Drop the shim when we move off 1.9.22.

Box tests opt into `CodegenTestDirectives.IGNORE_DEXING` so they don't require `com.android.tools.build:r8` just to verify JVM `box()` output.

## Test plan

- [x] `./gradlew :aspectk-compiler:test` runs `generateTests` then exercises all 11 tests; all pass
- [x] Stale `.fir.txt` / `.fir.ir.txt` golden files are regenerated automatically on the first run after a fixture changes; second run compares against the regenerated file
- [ ] Verify in CI (add `./gradlew :aspectk-compiler:test` to the workflow if one exists)
