### PR TITLE
Add v1 pointcut annotation set (Phase 1)

### DIFF
--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Annotated.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Annotated.kt
@@ -1,0 +1,23 @@
+package com.github.kitakkun.aspectk.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * Constrains an advice to target functions carrying at least one annotation whose
+ * class is listed in [values].
+ *
+ * Multiple [values] within a single annotation are OR-combined:
+ *
+ * ```kotlin
+ * @Annotated(Transactional::class, Cached::class)
+ * ```
+ *
+ * matches functions annotated with `@Transactional` or `@Cached`.
+ *
+ * Target annotations must have at least `BINARY` retention; `SOURCE`-retained
+ * annotations are invisible to the compiler plugin at IR time and will be flagged
+ * by a FIR diagnostic.
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class Annotated(vararg val values: KClass<out Annotation>)

--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ClassName.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ClassName.kt
@@ -1,0 +1,19 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Constrains an advice to target functions whose declaring class's simple name
+ * matches [pattern].
+ *
+ * Pattern syntax:
+ * - A literal name (`"UserRepository"`) matches that simple name exactly.
+ * - `*` matches zero or more characters at that position.
+ *   - `"*Repository"` matches `UserRepository`, `OrderRepository`, ….
+ *   - `"Abstract*"` matches `AbstractRepo`, `AbstractService`, ….
+ *   - `"*Repo*"` matches anything that contains `Repo`.
+ *   - `"*"` matches any class name (use to constrain via [Package] only).
+ *
+ * For top-level functions with no enclosing class, omit this annotation.
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class ClassName(val pattern: String)

--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/MethodName.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/MethodName.kt
@@ -1,0 +1,16 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Constrains an advice to target functions whose name matches [pattern].
+ *
+ * Pattern syntax:
+ * - A literal name (`"save"`) matches that method name exactly.
+ * - `*` matches zero or more characters at that position.
+ *   - `"save*"` matches `save`, `saveAll`, ….
+ *   - `"*Async"` matches `loadAsync`, `runAsync`, ….
+ *   - `"*find*"` matches anything that contains `find`.
+ *   - `"*"` matches any method name.
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class MethodName(val pattern: String)

--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Modality.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Modality.kt
@@ -1,0 +1,17 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Constrains an advice to target functions whose enclosing class modality is one
+ * of [values].
+ *
+ * `FINAL` matches classes without `open` / `abstract` / `sealed`. `OPEN` matches
+ * `open class` and `open fun` parents. `ABSTRACT` matches `abstract class` and
+ * `abstract fun`. `SEALED` matches `sealed class` and `sealed interface`.
+ *
+ * For top-level functions (no enclosing class) the annotation matches nothing.
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class Modality(vararg val values: Kind) {
+    enum class Kind { FINAL, OPEN, ABSTRACT, SEALED }
+}

--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Modifiers.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Modifiers.kt
@@ -1,0 +1,21 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Constrains an advice to target functions carrying every modifier listed in [values].
+ *
+ * Multiple modifiers within a single annotation are AND-combined (the function must
+ * carry *all* of them):
+ *
+ * ```kotlin
+ * @Modifiers(Modifiers.Kind.SUSPEND, Modifiers.Kind.INLINE)
+ * ```
+ *
+ * matches functions that are both `suspend` *and* `inline`. For OR semantics (a
+ * function carrying any of several modifiers), split the advice into multiple
+ * advice functions or wrap the modifier sets in `@Any` (Phase 5).
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class Modifiers(vararg val values: Kind) {
+    enum class Kind { SUSPEND, INLINE, INFIX, OPERATOR, TAILREC, EXTERNAL }
+}

--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Package.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Package.kt
@@ -1,0 +1,21 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Constrains an advice to target functions whose declaring package matches
+ * [pattern].
+ *
+ * Pattern syntax:
+ * - A literal name (`"com.example.repo"`) matches that package exactly.
+ * - `*` matches one whole segment (anything between two dots).
+ *   - `"com.example.*"` matches `com.example.foo`, `com.example.bar`, but **not**
+ *     `com.example` itself or `com.example.foo.bar`.
+ * - `**` matches zero or more whole segments.
+ *   - `"com.example.**"` matches `com.example`, `com.example.foo`, and
+ *     `com.example.foo.bar`.
+ *   - `"**.repo"` matches any package whose last segment is `repo`.
+ *
+ * For top-level functions with no package (the root package), use [pattern] = `""`.
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class Package(val pattern: String)

--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Pointcut.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Pointcut.kt
@@ -1,4 +1,31 @@
 package com.github.kitakkun.aspectk.annotations
 
-@Target(AnnotationTarget.FUNCTION)
-annotation class Pointcut(val expression: String)
+/**
+ * Marks an annotation class as a *reusable pointcut*.
+ *
+ * A pointcut annotation bundles a set of constraint annotations (e.g.
+ * [Visibility], [Package], [Annotated]) so they can be applied as one tag to
+ * many advice functions:
+ *
+ * ```kotlin
+ * @Pointcut
+ * @Visibility(Visibility.Kind.PUBLIC)
+ * @Package(prefix = "com.example.repo")
+ * @Annotated(Transactional::class)
+ * annotation class PublicTransactionalRepoCall
+ *
+ * @Aspect
+ * class TxAspect {
+ *     @Around
+ *     @PublicTransactionalRepoCall              // pulls in the three constraints above
+ *     @MethodName(startsWith = "save")          // can narrow further at the call site
+ *     fun BaseRepo.tx(user: User): Unit { … }
+ * }
+ * ```
+ *
+ * `@Pointcut`-marked annotations are expanded transitively, so a pointcut
+ * annotation can reference other pointcut annotations.
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class Pointcut

--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Visibility.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/Visibility.kt
@@ -1,0 +1,21 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Constrains an advice to target functions whose visibility is one of [values].
+ *
+ * Multiple values within a single annotation are OR-combined:
+ *
+ * ```kotlin
+ * @Visibility(Visibility.Kind.PUBLIC, Visibility.Kind.INTERNAL)
+ * ```
+ *
+ * matches public-or-internal functions.
+ *
+ * Stacking multiple `@Visibility` annotations on the same advice is not supported;
+ * use a single annotation with the union of intended visibilities.
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class Visibility(vararg val values: Kind) {
+    enum class Kind { PUBLIC, INTERNAL, PROTECTED, PRIVATE }
+}

--- a/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/LogAspect.kt
+++ b/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/LogAspect.kt
@@ -3,13 +3,12 @@ package com.github.kitakkun.aspectk.test
 import com.github.kitakkun.aspectk.annotations.After
 import com.github.kitakkun.aspectk.annotations.Aspect
 import com.github.kitakkun.aspectk.annotations.Before
-import com.github.kitakkun.aspectk.annotations.Pointcut
 
 @Aspect
 class LogAspect {
-    @Pointcut("execution(public *(..))")
-    fun allFunctions() {
-    }
+    // The v0.x `@Pointcut("execution(public *(..))") fun allFunctions()` declaration
+    // was removed when `@Pointcut` was repurposed as a meta-annotation marker for v1.
+    // Reusable pointcuts are now expressed as `@Pointcut`-marked annotation classes.
 
     @Before("args(String)")
     fun logString() {

--- a/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/V1Preview.kt
+++ b/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/V1Preview.kt
@@ -1,0 +1,45 @@
+package com.github.kitakkun.aspectk.test
+
+import com.github.kitakkun.aspectk.annotations.Annotated
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.Modality
+import com.github.kitakkun.aspectk.annotations.Modifiers
+import com.github.kitakkun.aspectk.annotations.Package
+import com.github.kitakkun.aspectk.annotations.Pointcut
+import com.github.kitakkun.aspectk.annotations.Visibility
+
+// --- Phase 1 compile-only preview --------------------------------------------
+//
+// Phase 1 only defines the new pointcut annotation set. The FIR checker
+// (Phase 2) and the IR transformer (Phase 3) do not look at any of this yet,
+// so applying these annotations has no runtime effect. The point of this file
+// is to verify that the annotation surface actually compiles from end-user code
+// the way the design intends.
+
+// A marker annotation used by [TransactionalRepoCall] below.
+annotation class Transactional
+
+// A reusable pointcut declared as a meta-annotation. Each constraint annotation
+// listed here is part of the bundle; applying [TransactionalRepoCall] to an
+// advice expands to all four constraints below.
+@Pointcut
+@Visibility(Visibility.Kind.PUBLIC)
+@Modality(Modality.Kind.OPEN, Modality.Kind.FINAL)
+@Modifiers(Modifiers.Kind.SUSPEND)
+@Package("com.github.kitakkun.aspectk.test.**")
+@ClassName("*Repo")
+@MethodName("save*")
+@Annotated(Transactional::class)
+annotation class TransactionalRepoCall
+
+@Aspect
+class V1PreviewAspect {
+    // Pulls in every constraint declared on [TransactionalRepoCall].
+    @TransactionalRepoCall
+    fun previewAdvice() {
+        // Phase 3 will replace this body's execution path with an
+        // advice-application IR transform.
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of `docs/v1-roadmap.md`: add the composable pointcut annotation set that will replace the v0.x string DSL. No plugin behaviour changes in this PR — the FIR checker and IR transformer were stubbed out in Phase 0 and the wiring is reintroduced in Phases 2-3. This PR just defines the surface so subsequent phases have something to consume.

**PR base**: `feat/upgrade-to-kotlin-latest` (Phase 0). Retarget to `develop` after Phase 0 lands.

## New annotations

Added under `com.github.kitakkun.aspectk.annotations`:

| Annotation | Shape | Role |
|---|---|---|
| `@Visibility(vararg Kind)` | `Kind { PUBLIC, INTERNAL, PROTECTED, PRIVATE }` | OR-combined visibility filter |
| `@Modality(vararg Kind)` | `Kind { FINAL, OPEN, ABSTRACT, SEALED }` | Enclosing-class modality filter |
| `@Modifiers(vararg Kind)` | `Kind { SUSPEND, INLINE, INFIX, OPERATOR, TAILREC, EXTERNAL }` | AND-combined modifier filter |
| `@Package(pattern)` | single string pattern | Package match with `*` / `**` wildcards |
| `@ClassName(pattern)` | single string pattern | Class-name pattern with `*` wildcard |
| `@MethodName(pattern)` | single string pattern | Method-name pattern with `*` wildcard |
| `@Annotated(vararg KClass<out Annotation>)` | OR over annotation classes | Annotation-marker targeting |

### Pattern syntax

`@Package` / `@ClassName` / `@MethodName` take a single `pattern: String`:

- A literal name matches exactly (`"save"`, `"UserRepo"`, `"com.example.repo"`).
- `*` matches zero or more characters within one segment:
  - `@MethodName("save*")` — prefix match.
  - `@MethodName("*Async")` — suffix match.
  - `@MethodName("*find*")` — contains.
  - `@MethodName("*")` — any name.
- `@Package` additionally accepts `**` to match across multiple segments:
  - `@Package("com.example.repo.**")` — the package itself plus all sub-packages.
  - `@Package("com.example.*")` — direct children of `com.example` only.
  - `@Package("**.repo")` — any package whose last segment is `repo`.

A single string replaces the original `value` / `startsWith` / `endsWith` / `contains` / `regex` parameter set: less cognitive load, and the `*` wildcard scales naturally from exact match to "anything".

## Redefined annotation

- `@Pointcut` — no longer takes a string argument. It is now a **meta-annotation marker**: applying it to an annotation class declares that annotation to be a reusable bundle of pointcut constraints.

This is the only breaking change in this PR. The v0.x form `@Pointcut("execution(...)")` is gone.

## Unchanged

- `@Aspect` is untouched.
- `@Before` / `@After` / `@Around` keep their v0.x string arguments **for now**. They become parameterless markers in Phase 3 when the IR transformer is rebuilt against the new model. Until then they remain valid (but have no runtime effect because the IR transformer is stubbed).

## Preview sample

[`test/V1Preview.kt`](test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/V1Preview.kt) is a compile-only preview that exercises the entire new annotation set:

```kotlin
@Pointcut
@Visibility(Visibility.Kind.PUBLIC)
@Modality(Modality.Kind.OPEN, Modality.Kind.FINAL)
@Modifiers(Modifiers.Kind.SUSPEND)
@Package("com.github.kitakkun.aspectk.test.**")
@ClassName("*Repo")
@MethodName("save*")
@Annotated(Transactional::class)
annotation class TransactionalRepoCall

@Aspect
class V1PreviewAspect {
    @TransactionalRepoCall
    fun previewAdvice() { /* … */ }
}
```

## Sample update

`test/.../LogAspect.kt` drops its `@Pointcut("execution(public *(..))") fun allFunctions()` declaration since the annotation no longer accepts a string. The rest of `LogAspect.kt` (legacy `@Before("args(String)")` etc.) remains for now and continues to compile.

## Test plan

- [x] `./gradlew build` is green on top of Phase 0.
- [x] `:test:compileKotlinJvm` compiles the new `V1PreviewAspect`.
- [ ] Phase 2 wires the FIR checker against this surface (pattern non-empty + valid).
- [ ] Phase 3 wires the IR transformer (the `previewAdvice` actually runs at matched call sites).

## Roadmap context

- ✅ **Phase 0** (#14) — Kotlin 2.3.21 upgrade.
- ✅ **Phase 1** — this PR — new annotation definitions.
- ⬜ **Phase 2** (#16) — FIR checker rebuild on the new model.
- ⬜ **Phase 3** — IR transformer rebuild + rewrite `@Before` / `@After` / `@Around` to parameterless markers.
- ⬜ **Phase 4** — delete `aspectk-expression`.
- ⬜ **Phase 5** — `@Any` / `@Not` logical composition.
- ⬜ **Phase 6** — meta-annotation expansion (transitive).
- ⬜ **Phase 7** — docs and sample rewrite.
