### PR TITLE
Rebuild FIR checker on the v1 annotation model (Phase 2)

### DIFF
--- a/aspectk-compiler/build.gradle.kts
+++ b/aspectk-compiler/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     alias(libs.plugins.aspectkCommon)
     alias(libs.plugins.kotlinJvm)
@@ -11,6 +13,10 @@ dependencies {
     compileOnly(libs.kotlin.compiler)
     compileOnly(libs.auto.service)
     ksp(libs.auto.service.ksp)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions.freeCompilerArgs.add("-Xcontext-parameters")
 }
 
 publishing {

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKAnnotations.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKAnnotations.kt
@@ -4,18 +4,34 @@ import org.jetbrains.kotlin.javac.resolve.classId
 import org.jetbrains.kotlin.name.Name
 
 object AspectKAnnotations {
-    val ASPECT_CLASS_ID = classId("com.github.kitakkun.aspectk.annotations", "Aspect")
-    val BEFORE_CLASS_ID = classId("com.github.kitakkun.aspectk.annotations", "Before")
-    val AFTER_CLASS_ID = classId("com.github.kitakkun.aspectk.annotations", "After")
-    val AROUND_CLASS_ID = classId("com.github.kitakkun.aspectk.annotations", "Around")
-    val POINTCUT_CLASS_ID = classId("com.github.kitakkun.aspectk.annotations", "Pointcut")
+    private const val PKG = "com.github.kitakkun.aspectk.annotations"
+
+    // advice / aspect markers (v0.x; kept for now, rewritten in Phase 3)
+    val ASPECT_CLASS_ID = classId(PKG, "Aspect")
+    val BEFORE_CLASS_ID = classId(PKG, "Before")
+    val AFTER_CLASS_ID = classId(PKG, "After")
+    val AROUND_CLASS_ID = classId(PKG, "Around")
 
     val ASPECT_FQ_NAME = ASPECT_CLASS_ID.asSingleFqName()
     val BEFORE_FQ_NAME = BEFORE_CLASS_ID.asSingleFqName()
     val AFTER_FQ_NAME = AFTER_CLASS_ID.asSingleFqName()
     val AROUND_FQ_NAME = AROUND_CLASS_ID.asSingleFqName()
+
+    // v1 pointcut annotations
+    val POINTCUT_CLASS_ID = classId(PKG, "Pointcut")
+    val VISIBILITY_CLASS_ID = classId(PKG, "Visibility")
+    val MODALITY_CLASS_ID = classId(PKG, "Modality")
+    val MODIFIERS_CLASS_ID = classId(PKG, "Modifiers")
+    val PACKAGE_CLASS_ID = classId(PKG, "Package")
+    val CLASS_NAME_CLASS_ID = classId(PKG, "ClassName")
+    val METHOD_NAME_CLASS_ID = classId(PKG, "MethodName")
+    val ANNOTATED_CLASS_ID = classId(PKG, "Annotated")
+
     val POINTCUT_FQ_NAME = POINTCUT_CLASS_ID.asSingleFqName()
 
-    val POINTCUT_ARGUMENT_EXPRESSION_NAME = Name.identifier("expression")
-    val ADVICE_ARGUMENT_POINTCUT_NAME = Name.identifier("pointcut")
+    val ADVICE_CLASS_IDS = setOf(BEFORE_CLASS_ID, AFTER_CLASS_ID, AROUND_CLASS_ID)
+
+    // common annotation argument names
+    val PATTERN = Name.identifier("pattern")
+    val VALUES = Name.identifier("values")
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrPluginContext.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrPluginContext.kt
@@ -11,4 +11,6 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
  * were specific to the string-DSL transformer and are dropped along with it. See
  * `docs/v1-roadmap.md`.
  */
-class AspectKIrPluginContext(val context: IrPluginContext) : IrPluginContext by context
+class AspectKIrPluginContext(
+    val context: IrPluginContext,
+) : IrPluginContext by context

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/AspectKFirExtensionRegistrar.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/AspectKFirExtensionRegistrar.kt
@@ -1,5 +1,6 @@
 package com.github.kitakkun.aspectk.compiler.fir
 
+import com.github.kitakkun.aspectk.compiler.fir.checker.AspectKErrors
 import com.github.kitakkun.aspectk.compiler.fir.checker.AspectKFirCheckerExtension
 import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
@@ -8,5 +9,6 @@ import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 class AspectKFirExtensionRegistrar : FirExtensionRegistrar() {
     override fun ExtensionRegistrarContext.configurePlugin() {
         +::AspectKFirCheckerExtension
+        registerDiagnosticContainers(AspectKErrors)
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AdviceScopeChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AdviceScopeChecker.kt
@@ -1,0 +1,50 @@
+package com.github.kitakkun.aspectk.compiler.fir.checker
+
+import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.fir.types.classId
+import org.jetbrains.kotlin.name.ClassId
+
+/**
+ * Errors when `@Before` / `@After` / `@Around` is applied to a function that is
+ * not a member of an `@Aspect`-annotated class.
+ */
+object AdviceScopeChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirNamedFunction) {
+        val adviceClassId = adviceClassIdOn(declaration) ?: return
+        if (declaration.isInsideAspectClass()) return
+
+        val src = declaration.source ?: return
+        reporter.reportOn(
+            src,
+            AspectKErrors.ADVICE_OUTSIDE_ASPECT_CLASS,
+            adviceClassId.shortClassName.asString(),
+        )
+    }
+
+    context(context: CheckerContext)
+    private fun adviceClassIdOn(declaration: FirNamedFunction): ClassId? {
+        for (classId in AspectKAnnotations.ADVICE_CLASS_IDS) {
+            if (declaration.hasAnnotation(classId, context.session)) return classId
+        }
+        return null
+    }
+
+    context(context: CheckerContext)
+    private fun FirNamedFunction.isInsideAspectClass(): Boolean {
+        val classId = dispatchReceiverType?.classId ?: return false
+        val classSymbol = context.session.symbolProvider.getClassLikeSymbolByClassId(classId)
+            as? FirRegularClassSymbol
+            ?: return false
+        return classSymbol.hasAnnotation(AspectKAnnotations.ASPECT_CLASS_ID, context.session)
+    }
+}

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
@@ -1,0 +1,45 @@
+package com.github.kitakkun.aspectk.compiler.fir.checker
+
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticsContainer
+import org.jetbrains.kotlin.diagnostics.error1
+import org.jetbrains.kotlin.diagnostics.error2
+import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
+import org.jetbrains.kotlin.diagnostics.rendering.CommonRenderers
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtFunction
+
+object AspectKErrors : KtDiagnosticsContainer() {
+    /** `@Before` / `@After` / `@Around` used outside an `@Aspect` class. */
+    val ADVICE_OUTSIDE_ASPECT_CLASS by error1<KtFunction, String>()
+
+    /** A pointcut annotation's parameters violate the constraints documented on its KDoc. */
+    val INVALID_POINTCUT_ANNOTATION by error2<KtAnnotationEntry, String, String>()
+
+    /** `@Annotated(Foo::class)` where `Foo` is `@Retention(SOURCE)` (invisible at IR time). */
+    val ANNOTATED_TARGETS_SOURCE_RETENTION by error1<KtAnnotationEntry, String>()
+
+    override fun getRendererFactory(): BaseDiagnosticRendererFactory = AspectKDefaultMessages
+}
+
+private object AspectKDefaultMessages : BaseDiagnosticRendererFactory() {
+    @Suppress("ktlint:standard:property-naming")
+    override val MAP: KtDiagnosticFactoryToRendererMap by KtDiagnosticFactoryToRendererMap("AspectK") { map ->
+        map.put(
+            AspectKErrors.ADVICE_OUTSIDE_ASPECT_CLASS,
+            "@{0} advice must be declared as a member of an @Aspect class.",
+            CommonRenderers.STRING,
+        )
+        map.put(
+            AspectKErrors.INVALID_POINTCUT_ANNOTATION,
+            "@{0}: {1}",
+            CommonRenderers.STRING,
+            CommonRenderers.STRING,
+        )
+        map.put(
+            AspectKErrors.ANNOTATED_TARGETS_SOURCE_RETENTION,
+            "@Annotated cannot target ''{0}'' because it has @Retention(SOURCE); use BINARY or RUNTIME retention.",
+            CommonRenderers.STRING,
+        )
+    }
+}

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKFirCheckerExtension.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKFirCheckerExtension.kt
@@ -2,16 +2,16 @@ package com.github.kitakkun.aspectk.compiler.fir.checker
 
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
 
-/**
- * Phase 0 stub.
- *
- * The v0.x extension installed three checkers (advice/pointcut scope, empty/invalid
- * pointcut expression, aspect class entries) that all parsed the soon-to-be-deleted
- * string DSL. Those rules are being rewritten from scratch in Phase 2 against the
- * new annotation + signature model. See `docs/v1-roadmap.md`.
- */
-class AspectKFirCheckerExtension(session: FirSession) : FirAdditionalCheckersExtension(session) {
-    override val declarationCheckers = object : DeclarationCheckers() {}
+class AspectKFirCheckerExtension(
+    session: FirSession,
+) : FirAdditionalCheckersExtension(session) {
+    override val declarationCheckers = object : DeclarationCheckers() {
+        override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker> = setOf(
+            AdviceScopeChecker,
+            PointcutAnnotationChecker,
+        )
+    }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/PointcutAnnotationChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/PointcutAnnotationChecker.kt
@@ -1,0 +1,54 @@
+package com.github.kitakkun.aspectk.compiler.fir.checker
+
+import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
+import org.jetbrains.kotlin.fir.declarations.getStringArgument
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.name.ClassId
+
+/**
+ * Validates the single `pattern: String` parameter on the v1 pointcut
+ * annotations `@Package` / `@ClassName` / `@MethodName`. An empty pattern
+ * is rejected at FIR time so the user gets a clear error rather than a
+ * silently-non-matching advice at runtime.
+ */
+object PointcutAnnotationChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+    private val annotationsToValidate = listOf(
+        AspectKAnnotations.PACKAGE_CLASS_ID to "Package",
+        AspectKAnnotations.CLASS_NAME_CLASS_ID to "ClassName",
+        AspectKAnnotations.METHOD_NAME_CLASS_ID to "MethodName",
+    )
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirNamedFunction) {
+        for ((classId, displayName) in annotationsToValidate) {
+            validatePatternNonEmpty(declaration, classId, displayName)
+        }
+    }
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    private fun validatePatternNonEmpty(
+        declaration: FirNamedFunction,
+        annotationClassId: ClassId,
+        annotationDisplayName: String,
+    ) {
+        val annotation: FirAnnotation =
+            declaration.getAnnotationByClassId(annotationClassId, context.session) ?: return
+        val pattern = annotation.getStringArgument(AspectKAnnotations.PATTERN, context.session)
+        if (!pattern.isNullOrEmpty()) return
+
+        val src = annotation.source ?: declaration.source ?: return
+        reporter.reportOn(
+            src,
+            AspectKErrors.INVALID_POINTCUT_ANNOTATION,
+            annotationDisplayName,
+            "pattern must not be empty",
+        )
+    }
+}

--- a/build-logic/src/main/kotlin/AspectKCommonConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AspectKCommonConventionPlugin.kt
@@ -11,7 +11,7 @@ class AspectKCommonConventionPlugin : Plugin<Project> {
             }
 
             configure<KtlintExtension> {
-                version.set("1.2.1")
+                version.set("1.6.0")
                 ignoreFailures.set(true)
             }
         }


### PR DESCRIPTION
## Summary

Phase 2 of `docs/v1-roadmap.md`: re-install FIR-time diagnostics now that the new pointcut annotation set landed in Phase 1. The Phase 0 stubs of the checker classes are replaced with concrete checks driven off annotation metadata; nothing in this PR depends on the (still-stubbed) IR transformer.

**PR base**: `feat/v1-phase1-annotations` (Phase 1). Retarget to `develop` after Phase 0 / Phase 1 merge.

## Checks restored / added

### `AdviceScopeChecker`

Errors when `@Before` / `@After` / `@Around` is applied to a function outside an `@Aspect` class. The check uses the dispatch receiver type to find the enclosing class rather than the deprecated `containingClass()` helper.

```kotlin
class NotAnAspect {
    @Before                                // → ADVICE_OUTSIDE_ASPECT_CLASS
    fun before() {}
}
```

### `PointcutAnnotationChecker`

Validates that the single `pattern: String` parameter on `@Package` / `@ClassName` / `@MethodName` is non-empty:

```kotlin
@Aspect
class MyAspect {
    @Before
    @MethodName("")          // → INVALID_POINTCUT_ANNOTATION (empty pattern)
    fun bad() {}
}
```

(Phase 1's API change collapsed the previous five-parameter shape — `value` / `startsWith` / `endsWith` / `contains` / `regex` — into a single `pattern` with `*` / `**` wildcards. The Phase 2 validator follows suit; "exactly one parameter non-empty" rule from the original Phase 2 design is no longer relevant.)

## Implementation notes

- `AspectKErrors` is a `KtDiagnosticsContainer` exposing three factories (`ADVICE_OUTSIDE_ASPECT_CLASS`, `INVALID_POINTCUT_ANNOTATION`, `ANNOTATED_TARGETS_SOURCE_RETENTION`). The renderer factory is registered through the container's `getRendererFactory()` override; the renderer map is built via the `KtDiagnosticFactoryToRendererMap` lambda-form delegate (the no-arg constructor is `internal` in Kotlin 2.3.21, so the lambda form is the only out-of-tree-friendly path).
- Container registration moved from `FirAdditionalCheckersExtension` (where v0.x kept it) to `FirExtensionRegistrar.configurePlugin()` via `registerDiagnosticContainers(AspectKErrors)` — the Kotlin 2.3 idiom.
- Checkers use the Kotlin 2.3 context-parameter form of `FirDeclarationChecker.check`. Added `-Xcontext-parameters` back to `aspectk-compiler/build.gradle.kts` (Phase 0 lost it during the cleanup and it's needed again here).

## Toolchain bump pulled in

`ktlint` is bumped from **1.2.1 → 1.6.0**. The 1.2.1 parser does not recognise the Kotlin 2.x `context(...)` parameter syntax and fails before lint rules even run; 1.6.0 (current latest stable) handles it correctly.

## Annotation constants

The new pointcut annotation FQNs and the `pattern` argument `Name` are centralised in `AspectKAnnotations`. The v0.x `ASPECT` / `BEFORE` / `AFTER` / `AROUND` / `POINTCUT` ClassIds remain alongside (their advice annotations still have string args until Phase 3).

## What is NOT done in this PR (deferred)

- `@Annotated` retention check (the SOURCE-retention diagnostic factory is declared but not yet emitted). Requires resolving the `KClass` arguments inside the annotation; left for a follow-up.
- Pointcut "matched zero declarations" warning — this needs IR-time match counts and naturally belongs in Phase 3.
- Pattern syntax validation (e.g. rejecting `@MethodName("**")` since `**` is only meaningful for packages, rejecting unbalanced wildcards). Left as a follow-up — Phase 3 must understand the pattern grammar anyway and can report parse failures from there.
- Meta-annotation expansion for `@Pointcut`-marked annotations is Phase 6.
- Logical composition (`@Any` / `@Not`) is Phase 5.

Test coverage will be reinstated alongside the Pattern B test harness rebuild that follows Phase 3.

## Roadmap context

- ✅ Phase 0 (#14) — Kotlin 2.3.21 upgrade.
- ✅ Phase 1 (#15) — new annotation definitions.
- ✅ Phase 2 — **this PR** — FIR checker rebuild.
- ⬜ Phase 3 — IR transformer rebuild + rewrite `@Before` / `@After` / `@Around` to parameterless markers.
- ⬜ Phase 4 — delete `aspectk-expression`.
- ⬜ Phase 5 — `@Any` / `@Not` logical composition.
- ⬜ Phase 6 — meta-annotation expansion (transitive).
- ⬜ Phase 7 — docs / sample rewrite + Pattern B test harness reinstatement.

## Test plan

- [x] `./gradlew build` is green on top of Phase 0 + Phase 1.
- [ ] Phase 3 reinstates Pattern B test harness; box / diagnostic tests covering these checkers added then.
