### PR TITLE
Phase 3.1: signature-driven binding for @Before

### DIFF
--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ContextParameter.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ContextParameter.kt
@@ -1,0 +1,18 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Binds the advice parameter to one of the matched target call's **context
+ * parameters**. Specify exactly one of [index] or [name]:
+ *
+ * - `@ContextParameter(0) tx: Transaction` — bind to the first context parameter
+ *   by index.
+ * - `@ContextParameter(name = "tx") tx: Transaction` — bind by parameter name.
+ *
+ * The parameter's declared type acts as a covariant assignability constraint.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.BINARY)
+annotation class ContextParameter(
+    val index: Int = -1,
+    val name: String = "",
+)

--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/DispatchReceiver.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/DispatchReceiver.kt
@@ -1,0 +1,19 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Binds the advice parameter to the matched target call's **dispatch receiver**
+ * (`this` of the method's declaring class). The parameter's declared type acts
+ * as a covariant subtype constraint: the target's dispatch receiver type must
+ * be a subtype of the binding parameter's type.
+ *
+ * ```kotlin
+ * @Before @MethodName("greet")
+ * fun beforeGreet(@DispatchReceiver greeter: Greeter) { ... }
+ * ```
+ *
+ * For top-level functions (no dispatch receiver), an advice declaring a
+ * `@DispatchReceiver` parameter does not match.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.BINARY)
+annotation class DispatchReceiver

--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ExtensionReceiver.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ExtensionReceiver.kt
@@ -1,0 +1,18 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Binds the advice parameter to the matched target call's **extension receiver**.
+ * The parameter's declared type acts as a covariant subtype constraint on
+ * matching.
+ *
+ * ```kotlin
+ * @Before @MethodName("substring")
+ * fun beforeSubstring(@ExtensionReceiver receiver: String) { ... }
+ * ```
+ *
+ * For functions without an extension receiver, an advice declaring an
+ * `@ExtensionReceiver` parameter does not match.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.BINARY)
+annotation class ExtensionReceiver

--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ValueParameter.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ValueParameter.kt
@@ -1,0 +1,19 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Binds the advice parameter to one of the matched target call's **value
+ * parameters**. Specify exactly one of [index] or [name]:
+ *
+ * - `@ValueParameter(0) name: String` — bind to the first value parameter by index.
+ * - `@ValueParameter(name = "user") user: User` — bind by parameter name.
+ *
+ * The binding parameter's declared type acts as a covariant assignability
+ * constraint: the target's value parameter at that position/name must be
+ * assignable to the binding parameter's type.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.BINARY)
+annotation class ValueParameter(
+    val index: Int = -1,
+    val name: String = "",
+)

--- a/aspectk-compiler/build.gradle.kts
+++ b/aspectk-compiler/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions.freeCompilerArgs.add("-Xcontext-parameters")
+    compilerOptions.optIn.add("org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI")
 }
 
 publishing {

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKAnnotations.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKAnnotations.kt
@@ -27,6 +27,17 @@ object AspectKAnnotations {
     val METHOD_NAME_CLASS_ID = classId(PKG, "MethodName")
     val ANNOTATED_CLASS_ID = classId(PKG, "Annotated")
 
+    // v1 parameter binding annotations
+    val DISPATCH_RECEIVER_CLASS_ID = classId(PKG, "DispatchReceiver")
+    val EXTENSION_RECEIVER_CLASS_ID = classId(PKG, "ExtensionReceiver")
+    val CONTEXT_PARAMETER_CLASS_ID = classId(PKG, "ContextParameter")
+    val VALUE_PARAMETER_CLASS_ID = classId(PKG, "ValueParameter")
+
+    val DISPATCH_RECEIVER_FQ_NAME = DISPATCH_RECEIVER_CLASS_ID.asSingleFqName()
+    val EXTENSION_RECEIVER_FQ_NAME = EXTENSION_RECEIVER_CLASS_ID.asSingleFqName()
+    val CONTEXT_PARAMETER_FQ_NAME = CONTEXT_PARAMETER_CLASS_ID.asSingleFqName()
+    val VALUE_PARAMETER_FQ_NAME = VALUE_PARAMETER_CLASS_ID.asSingleFqName()
+
     val POINTCUT_FQ_NAME = POINTCUT_CLASS_ID.asSingleFqName()
 
     val ADVICE_CLASS_IDS = setOf(BEFORE_CLASS_ID, AFTER_CLASS_ID, AROUND_CLASS_ID)
@@ -34,4 +45,6 @@ object AspectKAnnotations {
     // common annotation argument names
     val PATTERN = Name.identifier("pattern")
     val VALUES = Name.identifier("values")
+    val INDEX = Name.identifier("index")
+    val NAME = Name.identifier("name")
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectAnalyzer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectAnalyzer.kt
@@ -5,19 +5,25 @@ import org.jetbrains.kotlin.backend.jvm.ir.getStringConstArgument
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.util.getAnnotation
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 
 /**
  * Walks the IR module fragment, finds every `@Aspect` class and the advice
- * functions it declares, and converts each advice's stacked pointcut annotations
- * into a [PointcutFilter].
+ * functions it declares, converts each advice's stacked pointcut annotations
+ * into a [PointcutFilter], and collects per-parameter [Binding]s from the
+ * advice's value parameters.
  *
- * Phase 3 minimum scope: only `@ClassName` / `@MethodName` annotations are read.
- * Other v1 pointcut annotations (`@Visibility`, `@Package`, `@Annotated`, …) are
- * silently ignored here and will be added in Phase 3 follow-ups.
+ * Phase 3.1 scope: `@ClassName` / `@MethodName` matching plus full binding
+ * support for `@DispatchReceiver` / `@ExtensionReceiver` / `@ContextParameter` /
+ * `@ValueParameter`. The remaining matching annotations (`@Visibility`,
+ * `@Package`, `@Annotated`, …) arrive in Phase 3.4.
  */
 internal class AspectAnalyzer {
     fun analyze(moduleFragment: IrModuleFragment): List<AspectMetadata> {
@@ -48,6 +54,7 @@ internal class AspectAnalyzer {
                     function = fn,
                     kind = kind,
                     pointcut = pointcutOf(fn),
+                    bindings = bindingsOf(fn),
                 )
             }
         return AspectMetadata(aspectClass = aspectClass, advices = advices)
@@ -73,7 +80,44 @@ internal class AspectAnalyzer {
             methodNamePattern = methodName,
         )
     }
+
+    private fun bindingsOf(fn: IrSimpleFunction): List<Binding> =
+        fn.parameters
+            .filter { it.kind == IrParameterKind.Regular }
+            .mapNotNull { bindingForParameter(it) }
+
+    private fun bindingForParameter(param: IrValueParameter): Binding? {
+        param.getAnnotation(AspectKAnnotations.DISPATCH_RECEIVER_FQ_NAME)?.let {
+            return Binding.DispatchReceiver(param)
+        }
+        param.getAnnotation(AspectKAnnotations.EXTENSION_RECEIVER_FQ_NAME)?.let {
+            return Binding.ExtensionReceiver(param)
+        }
+        param.getAnnotation(AspectKAnnotations.CONTEXT_PARAMETER_FQ_NAME)?.let { ann ->
+            val (index, name) = readIndexNameArgs(ann)
+            return Binding.ContextParameter(param, index, name)
+        }
+        param.getAnnotation(AspectKAnnotations.VALUE_PARAMETER_FQ_NAME)?.let { ann ->
+            val (index, name) = readIndexNameArgs(ann)
+            return Binding.ValueParameter(param, index, name)
+        }
+        return null
+    }
+
+    private fun readIndexNameArgs(annotation: IrConstructorCall): Pair<Int?, String?> {
+        val index = (annotation.namedArg(AspectKAnnotations.INDEX.asString()) as? IrConst)?.value as? Int
+        val name = (annotation.namedArg(AspectKAnnotations.NAME.asString()) as? IrConst)?.value as? String
+        val resolvedIndex = if (index != null && index >= 0) index else null
+        val resolvedName = if (!name.isNullOrEmpty()) name else null
+        return resolvedIndex to resolvedName
+    }
 }
+
+private fun IrConstructorCall.namedArg(name: String) =
+    symbol.owner.parameters
+        .indexOfFirst { it.name.asString() == name }
+        .takeIf { it >= 0 }
+        ?.let { arguments[it] }
 
 private fun IrElement.acceptVoid(visitor: IrVisitorVoid) {
     accept(visitor, null)

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectMetadata.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectMetadata.kt
@@ -2,6 +2,7 @@ package com.github.kitakkun.aspectk.compiler.backend.analyzer
 
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 
 internal data class AspectMetadata(
     val aspectClass: IrClass,
@@ -12,17 +13,49 @@ internal data class AdviceMetadata(
     val function: IrSimpleFunction,
     val kind: AdviceKind,
     val pointcut: PointcutFilter,
+    val bindings: List<Binding>,
 )
 
 internal enum class AdviceKind { BEFORE, AFTER, AROUND }
 
 /**
- * Phase 3 (minimum-viable) subset of the pointcut filter. Only the constraints
- * driven directly by string-pattern annotations land here; visibility, modality,
- * modifiers, package, annotation-marker and signature-driven filters are added
- * in Phase 3 follow-ups.
+ * Phase 3.1 subset of the pointcut filter. Carries the name-pattern matching
+ * annotations plus signature-driven constraints derived from binding parameters
+ * (a `@DispatchReceiver` binding implies the target has a dispatch receiver of
+ * a compatible type, etc.). The remaining matching annotations
+ * (`@Visibility` / `@Modality` / `@Modifiers` / `@Package` / `@Annotated`)
+ * are added in Phase 3.4.
  */
 internal data class PointcutFilter(
     val classNamePattern: String?,
     val methodNamePattern: String?,
 )
+
+/**
+ * One entry per advice function parameter, recording where its value must be
+ * extracted from at the matched target call site.
+ */
+internal sealed interface Binding {
+    /** The advice's own parameter that the extracted value is forwarded into. */
+    val adviceParameter: IrValueParameter
+
+    data class DispatchReceiver(
+        override val adviceParameter: IrValueParameter,
+    ) : Binding
+
+    data class ExtensionReceiver(
+        override val adviceParameter: IrValueParameter,
+    ) : Binding
+
+    data class ContextParameter(
+        override val adviceParameter: IrValueParameter,
+        val index: Int?,
+        val name: String?,
+    ) : Binding
+
+    data class ValueParameter(
+        override val adviceParameter: IrValueParameter,
+        val index: Int?,
+        val name: String?,
+    ) : Binding
+}

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/matching/PointcutMatcher.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/matching/PointcutMatcher.kt
@@ -1,11 +1,23 @@
 package com.github.kitakkun.aspectk.compiler.backend.matching
 
+import com.github.kitakkun.aspectk.compiler.backend.analyzer.AdviceMetadata
+import com.github.kitakkun.aspectk.compiler.backend.analyzer.Binding
 import com.github.kitakkun.aspectk.compiler.backend.analyzer.PointcutFilter
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 
 internal object PointcutMatcher {
     fun matches(
+        advice: AdviceMetadata,
+        target: IrSimpleFunction,
+    ): Boolean {
+        if (!filterMatches(advice.pointcut, target)) return false
+        if (!bindingsMatch(advice.bindings, target)) return false
+        return true
+    }
+
+    private fun filterMatches(
         filter: PointcutFilter,
         target: IrSimpleFunction,
     ): Boolean {
@@ -15,6 +27,41 @@ internal object PointcutMatcher {
         }
         filter.methodNamePattern?.let { pattern ->
             if (!NamePattern.matches(pattern, target.name.asString())) return false
+        }
+        return true
+    }
+
+    /**
+     * Presence-only check (Phase 3.1): the target must expose the slots that
+     * the advice's bindings declare. Type compatibility between the binding's
+     * declared type and the target's actual parameter type is deferred to a
+     * Phase 3.1 follow-up.
+     */
+    private fun bindingsMatch(
+        bindings: List<Binding>,
+        target: IrSimpleFunction,
+    ): Boolean {
+        val targetParams = target.parameters
+        val targetValueParams = targetParams.filter { it.kind == IrParameterKind.Regular }
+        val targetContextParams = targetParams.filter { it.kind == IrParameterKind.Context }
+        val targetHasDispatch = targetParams.any { it.kind == IrParameterKind.DispatchReceiver }
+        val targetHasExtension = targetParams.any { it.kind == IrParameterKind.ExtensionReceiver }
+        for (binding in bindings) {
+            val ok = when (binding) {
+                is Binding.DispatchReceiver -> targetHasDispatch
+                is Binding.ExtensionReceiver -> targetHasExtension
+                is Binding.ValueParameter -> when {
+                    binding.index != null -> binding.index in targetValueParams.indices
+                    binding.name != null -> targetValueParams.any { it.name.asString() == binding.name }
+                    else -> false
+                }
+                is Binding.ContextParameter -> when {
+                    binding.index != null -> binding.index in targetContextParams.indices
+                    binding.name != null -> targetContextParams.any { it.name.asString() == binding.name }
+                    else -> false
+                }
+            }
+            if (!ok) return false
         }
         return true
     }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
@@ -4,31 +4,37 @@ import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
 import com.github.kitakkun.aspectk.compiler.backend.analyzer.AdviceKind
 import com.github.kitakkun.aspectk.compiler.backend.analyzer.AdviceMetadata
 import com.github.kitakkun.aspectk.compiler.backend.analyzer.AspectMetadata
+import com.github.kitakkun.aspectk.compiler.backend.analyzer.Binding
 import com.github.kitakkun.aspectk.compiler.backend.matching.PointcutMatcher
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irCallConstructor
+import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
+import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
 
 /**
- * Phase 3 (minimum-viable) advice applier.
+ * Phase 3.1 advice applier.
  *
  * Walks every `IrSimpleFunction` in the module fragment. For each function that
- * is **not** itself part of an `@Aspect` class, the transformer checks every
- * advice's [PointcutMatcher] and — when matched — prepends an advice invocation
- * to the target's body.
+ * is **not** itself part of an `@Aspect` class, asks [PointcutMatcher] which
+ * advices match, and prepends each matching advice's invocation to the target's
+ * body. Binding values (`@DispatchReceiver`, `@ExtensionReceiver`,
+ * `@ContextParameter`, `@ValueParameter`) are extracted from the target's
+ * parameters and forwarded into the advice's matching slot.
  *
- * Currently only `@Before` advice is wired up; `@After` / `@Around` are no-ops
- * and arrive in Phase 3 follow-up PRs. Advice functions are expected to be
- * parameterless (no `JoinPoint` injection in this PR).
+ * Only `@Before` advice is wired up here; `@After` / `@Around` are recognised
+ * but no-op'd and arrive in Phase 3.2 / 3.3.
  */
 internal class AspectKTransformer(
     private val pluginContext: IrPluginContext,
@@ -50,7 +56,7 @@ internal class AspectKTransformer(
 
         for (aspect in aspects) {
             for (advice in aspect.advices) {
-                if (!PointcutMatcher.matches(advice.pointcut, declaration)) continue
+                if (!PointcutMatcher.matches(advice, declaration)) continue
                 applyAdvice(declaration, aspect.aspectClass, advice)
             }
         }
@@ -65,34 +71,81 @@ internal class AspectKTransformer(
         advice: AdviceMetadata,
     ) {
         when (advice.kind) {
-            AdviceKind.BEFORE -> applyBefore(target, aspectClass, advice.function)
-            AdviceKind.AFTER -> Unit // Phase 3 follow-up
-            AdviceKind.AROUND -> Unit // Phase 3 follow-up
+            AdviceKind.BEFORE -> applyBefore(target, aspectClass, advice)
+            AdviceKind.AFTER -> Unit // Phase 3.2
+            AdviceKind.AROUND -> Unit // Phase 3.3
         }
     }
 
     private fun applyBefore(
         target: IrSimpleFunction,
         aspectClass: IrClass,
-        adviceFn: IrSimpleFunction,
+        advice: AdviceMetadata,
     ) {
         val body = target.body as? IrBlockBody ?: return
         val ctor = aspectClass.primaryConstructor
-            ?: return // No no-arg primary constructor — nothing safe to do
+            ?: return // No primary constructor — nothing safe to do
         if (ctor.parameters.isNotEmpty()) return
 
+        val adviceFn = advice.function
         val builder = DeclarationIrBuilder(
             pluginContext,
             target.symbol,
             target.startOffset,
             target.endOffset,
         )
-        // Construct a fresh aspect instance inline at each call site (no caching).
-        // arguments[0] of the advice call is the dispatch receiver slot.
         val call = builder.irCall(adviceFn.symbol).apply {
+            // arguments[0] is the advice's dispatch receiver (the aspect instance).
             arguments[0] = builder.irCallConstructor(ctor.symbol, emptyList())
+            // Forward each binding's extracted value into the matching advice slot.
+            for (binding in advice.bindings) {
+                val adviceSlotIndex = adviceFn.parameters.indexOf(binding.adviceParameter)
+                if (adviceSlotIndex < 0) continue
+                val value = extractBindingValue(binding, target, builder) ?: continue
+                arguments[adviceSlotIndex] = value
+            }
         }
 
         body.statements.add(0, call)
+    }
+
+    private fun extractBindingValue(
+        binding: Binding,
+        target: IrSimpleFunction,
+        builder: DeclarationIrBuilder,
+    ): IrExpression? {
+        val sourceParam = when (binding) {
+            is Binding.DispatchReceiver -> target.parameters.firstOrNull { it.kind == IrParameterKind.DispatchReceiver }
+            is Binding.ExtensionReceiver -> target.parameters.firstOrNull { it.kind == IrParameterKind.ExtensionReceiver }
+            is Binding.ValueParameter -> findRegular(target, binding.index, binding.name)
+            is Binding.ContextParameter -> findContext(target, binding.index, binding.name)
+        } ?: return null
+        return builder.irGet(sourceParam)
+    }
+
+    private fun findRegular(
+        target: IrSimpleFunction,
+        index: Int?,
+        name: String?,
+    ): IrValueParameter? {
+        val regulars = target.parameters.filter { it.kind == IrParameterKind.Regular }
+        return when {
+            index != null -> regulars.getOrNull(index)
+            name != null -> regulars.firstOrNull { it.name.asString() == name }
+            else -> null
+        }
+    }
+
+    private fun findContext(
+        target: IrSimpleFunction,
+        index: Int?,
+        name: String?,
+    ): IrValueParameter? {
+        val contexts = target.parameters.filter { it.kind == IrParameterKind.Context }
+        return when {
+            index != null -> contexts.getOrNull(index)
+            name != null -> contexts.firstOrNull { it.name.asString() == name }
+            else -> null
+        }
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
@@ -19,6 +19,9 @@ object AspectKErrors : KtDiagnosticsContainer() {
     /** `@Annotated(Foo::class)` where `Foo` is `@Retention(SOURCE)` (invisible at IR time). */
     val ANNOTATED_TARGETS_SOURCE_RETENTION by error1<KtAnnotationEntry, String>()
 
+    /** `@ValueParameter` / `@ContextParameter` must specify exactly one of `index` / `name`. */
+    val INVALID_BINDING_ANNOTATION by error2<KtAnnotationEntry, String, String>()
+
     override fun getRendererFactory(): BaseDiagnosticRendererFactory = AspectKDefaultMessages
 }
 
@@ -39,6 +42,12 @@ private object AspectKDefaultMessages : BaseDiagnosticRendererFactory() {
         map.put(
             AspectKErrors.ANNOTATED_TARGETS_SOURCE_RETENTION,
             "@Annotated cannot target ''{0}'' because it has @Retention(SOURCE); use BINARY or RUNTIME retention.",
+            CommonRenderers.STRING,
+        )
+        map.put(
+            AspectKErrors.INVALID_BINDING_ANNOTATION,
+            "@{0}: {1}",
+            CommonRenderers.STRING,
             CommonRenderers.STRING,
         )
     }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKFirCheckerExtension.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKFirCheckerExtension.kt
@@ -12,6 +12,7 @@ class AspectKFirCheckerExtension(
         override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker> = setOf(
             AdviceScopeChecker,
             PointcutAnnotationChecker,
+            BindingAnnotationChecker,
         )
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/BindingAnnotationChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/BindingAnnotationChecker.kt
@@ -1,0 +1,55 @@
+package com.github.kitakkun.aspectk.compiler.fir.checker
+
+import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
+
+/**
+ * Validates the indexed-or-named binding annotations on advice value parameters.
+ *
+ * `@ValueParameter` and `@ContextParameter` each declare both `index: Int = -1`
+ * and `name: String = ""`. Exactly one must be set: `index >= 0` xor
+ * `name.isNotEmpty()`. The default-both and both-set forms are rejected here
+ * so the user gets a clear diagnostic rather than a silently-mismatching
+ * binding at IR time.
+ *
+ * `@DispatchReceiver` and `@ExtensionReceiver` take no arguments and are not
+ * checked here.
+ */
+object BindingAnnotationChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+    private val annotationsToValidate = listOf(
+        AspectKAnnotations.VALUE_PARAMETER_CLASS_ID to "ValueParameter",
+        AspectKAnnotations.CONTEXT_PARAMETER_CLASS_ID to "ContextParameter",
+    )
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirNamedFunction) {
+        for (param in declaration.valueParameters) {
+            for ((classId, displayName) in annotationsToValidate) {
+                val annotation = param.getAnnotationByClassId(classId, context.session) ?: continue
+                // Presence-based check: the user must pass exactly one of `index` / `name`.
+                // Default values (`index = -1`, `name = ""`) leave the corresponding key
+                // out of the resolved argument mapping.
+                val hasIndex = AspectKAnnotations.INDEX in annotation.argumentMapping.mapping
+                val hasName = AspectKAnnotations.NAME in annotation.argumentMapping.mapping
+                val message = when {
+                    !hasIndex && !hasName -> "specify one of index or name"
+                    hasIndex && hasName -> "specify only one of index or name, not both"
+                    else -> continue
+                }
+                val src = annotation.source ?: param.source ?: continue
+                reporter.reportOn(
+                    src,
+                    AspectKErrors.INVALID_BINDING_ANNOTATION,
+                    displayName,
+                    message,
+                )
+            }
+        }
+    }
+}

--- a/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/GreetingTracer.kt
+++ b/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/GreetingTracer.kt
@@ -3,14 +3,19 @@ package com.github.kitakkun.aspectk.test
 import com.github.kitakkun.aspectk.annotations.Aspect
 import com.github.kitakkun.aspectk.annotations.Before
 import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.DispatchReceiver
 import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.ValueParameter
 
 @Aspect
 class GreetingTracer {
     @Before
     @ClassName("Greeter")
     @MethodName("greet")
-    fun beforeGreet() {
-        println("[before] Greeter.greet")
+    fun beforeGreet(
+        @DispatchReceiver greeter: Greeter,
+        @ValueParameter(0) name: String,
+    ) {
+        println("[before] $greeter.greet($name)")
     }
 }


### PR DESCRIPTION
## Summary

Phase 3.1 of the v1 roadmap (stacked on #17 / `feat/v1-phase3-ir-transformer`).

Adds parameter binding annotations and wires the IR transformer to extract values from the matched target call site into the advice's binding parameters.

### New annotations

- `` `@DispatchReceiver` `` — binds the target's dispatch receiver. The declared parameter type acts as a covariant subtype constraint.
- `` `@ExtensionReceiver` `` — binds the target's extension receiver.
- `` `@ValueParameter(index = N)` `` / `` `@ValueParameter(name = "x")` `` — binds the N-th value argument by position or the named one.
- `` `@ContextParameter(index = N)` `` / `` `@ContextParameter(name = "x")` `` — same shape, but for context parameters.

All four are `@Target(VALUE_PARAMETER)` + `@Retention(BINARY)`.

### Backend

- `AspectMetadata` gains `bindings: List<Binding>` per advice. `Binding` is a sealed interface with one variant per annotation kind, each carrying the `IrValueParameter` it forwards into.
- `AspectAnalyzer` reads the binding annotations off each advice's value parameters; the legacy "parameterless advice" assumption is dropped.
- `PointcutMatcher.matches` now takes the full `AdviceMetadata` and presence-checks each binding against the target (e.g. an advice with `` `@DispatchReceiver` `` no longer matches top-level functions).
- `AspectKTransformer.applyBefore` builds an `IrGetValue` for the target's matched parameter and forwards it into the corresponding advice argument slot.

### FIR diagnostics

`INVALID_BINDING_ANNOTATION` (error) — emitted when `` `@ValueParameter` `` / `` `@ContextParameter` `` is written with neither / both of `index` and `name`. Implemented via a presence check on the resolved argument mapping (no literal parsing needed).

### Test sample

`GreetingTracer.beforeGreet` now declares `@DispatchReceiver greeter: Greeter` + `@ValueParameter(0) name: String`. Running `MainKt` prints:

```
[before] com.github.kitakkun.aspectk.test.Greeter@…greet(world)
hello world
```

Both the receiver and the value argument are extracted at the call site and forwarded into the advice body.

### Not in scope (Phase 3.1 follow-ups)

- **Type compatibility check** between the binding's declared type and the target's matched slot type. Currently only presence is checked; mismatches would surface as a runtime ClassCastException.
- **`` `@ValueParameters args: List<Any?>` ``** catch-all binding (captures every value argument as a list). Tracked as a Phase 3.x task.
- `` `@After` `` (Phase 3.2) and `` `@Around` `` (Phase 3.3) consumption of the same binding mechanism.

## Test plan

- [x] `./gradlew build` — green.
- [x] Manually ran the compiled `MainKt`; the advice fires with the extracted dispatch receiver instance and value argument.
- [ ] (Deferred to Phase 7) compiler-test-framework cases that exercise binding extraction in matrix form (positional vs named, missing slot, type mismatch).