### PR TITLE
Phase 3.3: @Around advice with interceptableAdvice + proceed + replace*

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKAnnotations.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKAnnotations.kt
@@ -1,10 +1,12 @@
 package com.github.kitakkun.aspectk.compiler
 
 import org.jetbrains.kotlin.javac.resolve.classId
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 object AspectKAnnotations {
     private const val PKG = "com.github.kitakkun.aspectk.annotations"
+    private const val CORE_PKG = "com.github.kitakkun.aspectk.core"
 
     // advice / aspect markers (v0.x; kept for now, rewritten in Phase 3)
     val ASPECT_CLASS_ID = classId(PKG, "Aspect")
@@ -41,6 +43,12 @@ object AspectKAnnotations {
     val POINTCUT_FQ_NAME = POINTCUT_CLASS_ID.asSingleFqName()
 
     val ADVICE_CLASS_IDS = setOf(BEFORE_CLASS_ID, AFTER_CLASS_ID, AROUND_CLASS_ID)
+
+    // v1 @Around runtime markers
+    val AROUND_SCOPE_CLASS_ID = classId(CORE_PKG, "AroundScope")
+    val AROUND_SCOPE_FQ_NAME = AROUND_SCOPE_CLASS_ID.asSingleFqName()
+    val INTERCEPTABLE_ADVICE_FQ_NAME = FqName("$CORE_PKG.interceptableAdvice")
+    val PROCEED_NAME = Name.identifier("proceed")
 
     // common annotation argument names
     val PATTERN = Name.identifier("pattern")

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
@@ -9,13 +9,17 @@ import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irReturn
+import org.jetbrains.kotlin.ir.builders.irSet
+import org.jetbrains.kotlin.ir.builders.irTemporary
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
@@ -27,21 +31,27 @@ import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
 
 /**
- * Phase 3.3a `@Around` advice weaver (minimum-viable scope).
+ * Phase 3.3 `@Around` advice weaver.
  *
  * For each `(target, around-advice)` match, this weaver:
  *
  * 1. Extracts the lambda body from the advice's `interceptableAdvice<R> { ... }`
  *    invocation.
- * 2. Deep-clones the lambda body so each target site gets an independent copy.
- * 3. Inside the cloned body, rewrites:
- *    - References to advice binding parameters into `IrGetValue` reads of the
- *      target's matching slot.
- *    - Calls to `AroundScope.proceed()` into a fresh clone of the target's
- *      original return-value expression.
+ * 2. Declares one mutable local variable per advice binding (`__<slotName>`),
+ *    each initialised from the target's matching parameter slot.
+ * 3. Deep-clones the lambda body so each target site gets an independent copy.
+ * 4. Inside the cloned body, rewrites:
+ *    - `IrGetValue` reads of the advice binding parameters into reads of the
+ *      corresponding local variable.
+ *    - `AroundScope.replace*(…, value)` calls into `IrSetValue` assignments
+ *      against the local variable for the targeted slot.
+ *    - `AroundScope.proceed()` calls into a fresh clone of the target's
+ *      original return-value expression, with reads of the target's
+ *      parameter slots remapped to reads of the local variables (so the
+ *      current override state flows into the call).
  *    - `IrReturn`s that targeted the lambda into `IrReturn`s targeting the
  *      target function (so the value escapes both the lambda and the target).
- * 4. Replaces the target's body with the substituted block.
+ * 5. Replaces the target's body with the substituted block.
  *
  * Constraints carried by this minimum-viable cut:
  *
@@ -49,9 +59,17 @@ import org.jetbrains.kotlin.ir.visitors.IrTransformer
  *   sole statement is an `IrReturn`). Multi-statement bodies and
  *   `IrExpressionBody` are deferred.
  * - The aspect class must have a no-arg primary constructor.
- * - The `replace*` family on `AroundScope` is left untransformed; calling any
- *   of them at runtime throws via the stub in `aspectk-core`. Phase 3.3b
- *   wires them up.
+ * - `replaceValueParameter` / `replaceContextParameter` need a *constant*
+ *   first argument (index `IrConst<Int>` or name `IrConst<String>`); a
+ *   non-const slot identifier is left untransformed and would throw at
+ *   runtime via the `aspectk-core` stub.
+ * - The bind-first rule (replace targets a slot that must also be bound) is
+ *   enforced indirectly: only slots with declared bindings get a local
+ *   variable, so an unbound `replace*` call has no local to target and is
+ *   silently left as the runtime-throwing stub call. A dedicated FIR
+ *   checker arrives in a follow-up.
+ * - Combining `@Around` with `@Before` / `@After` on the same target is
+ *   undefined — `@Around` replaces the body.
  *
  * The advice function itself is left untouched — the lambda body is cloned
  * out of it and used as a template.
@@ -73,25 +91,51 @@ internal class AroundAdviceWeaver(
 
         val originalReturnValue = singleReturnValue(target) ?: return false
 
-        val paramSubst = buildParameterSubstitution(advice.bindings, target)
-
-        val clonedBody = adviceLambdaBody.deepCopyWithSymbols(initialParent = target)
         val builder = DeclarationIrBuilder(
             pluginContext,
             target.symbol,
             target.startOffset,
             target.endOffset,
         )
-        val substitution = AroundSubstitutionTransformer(
-            builder = builder,
-            paramSubst = paramSubst,
-            proceedReplacement = { originalReturnValue.deepCopyWithSymbols(initialParent = target) },
-            lambdaFunction = lambdaFn,
-            target = target,
-        )
-        clonedBody.transformChildren(substitution, null)
 
         target.body = builder.irBlockBody {
+            // 1. Declare one mutable local per bound slot, initialised from
+            //    the matching target parameter. `irTemporary` is an
+            //    `IrStatementsBuilder` extension, so locals are appended to
+            //    this block in declaration order.
+            val slotToLocal = linkedMapOf<IrValueParameter, IrVariable>()
+            for (binding in advice.bindings) {
+                val slot = findTargetSlot(binding, target) ?: continue
+                slotToLocal.getOrPut(slot) {
+                    irTemporary(
+                        value = irGet(slot),
+                        nameHint = "__${slot.name.asString()}",
+                        isMutable = true,
+                    )
+                }
+            }
+
+            // 2. Map each advice binding parameter to its local.
+            val paramToLocal = mutableMapOf<IrValueParameter, IrVariable>()
+            for (binding in advice.bindings) {
+                val slot = findTargetSlot(binding, target) ?: continue
+                val local = slotToLocal[slot] ?: continue
+                paramToLocal[binding.adviceParameter] = local
+            }
+
+            // 3. Clone the advice's lambda body and rewrite parameter reads,
+            //    replace* calls, proceed() calls, and lambda-targeted returns.
+            val clonedBody = adviceLambdaBody.deepCopyWithSymbols(initialParent = target)
+            val substitution = AroundSubstitutionTransformer(
+                builder = builder,
+                paramToLocal = paramToLocal,
+                slotToLocal = slotToLocal,
+                target = target,
+                originalReturnValue = originalReturnValue,
+                lambdaFunction = lambdaFn,
+            )
+            clonedBody.transformChildren(substitution, null)
+
             for (stmt in clonedBody.statements) +stmt
         }
         return true
@@ -113,18 +157,6 @@ internal class AroundAdviceWeaver(
         val body = target.body as? IrBlockBody ?: return null
         val ret = body.statements.singleOrNull() as? IrReturn ?: return null
         return ret.value
-    }
-
-    private fun buildParameterSubstitution(
-        bindings: List<Binding>,
-        target: IrSimpleFunction,
-    ): Map<IrValueParameter, IrValueParameter> {
-        val map = mutableMapOf<IrValueParameter, IrValueParameter>()
-        for (binding in bindings) {
-            val targetSlot = findTargetSlot(binding, target) ?: continue
-            map[binding.adviceParameter] = targetSlot
-        }
-        return map
     }
 
     private fun findTargetSlot(
@@ -157,10 +189,11 @@ internal class AroundAdviceWeaver(
 
 private class AroundSubstitutionTransformer(
     private val builder: DeclarationIrBuilder,
-    private val paramSubst: Map<IrValueParameter, IrValueParameter>,
-    private val proceedReplacement: () -> IrExpression,
-    private val lambdaFunction: IrFunction,
+    private val paramToLocal: Map<IrValueParameter, IrVariable>,
+    private val slotToLocal: Map<IrValueParameter, IrVariable>,
     private val target: IrSimpleFunction,
+    private val originalReturnValue: IrExpression,
+    private val lambdaFunction: IrFunction,
 ) : IrTransformer<Nothing?>() {
     override fun visitElement(
         element: IrElement,
@@ -174,15 +207,22 @@ private class AroundSubstitutionTransformer(
         expression: IrGetValue,
         data: Nothing?,
     ): IrExpression {
-        val targetSlot = paramSubst[expression.symbol.owner]
-        return if (targetSlot != null) builder.irGet(targetSlot) else expression
+        val local = paramToLocal[expression.symbol.owner]
+        return if (local != null) builder.irGet(local) else expression
     }
 
     override fun visitCall(
         expression: IrCall,
         data: Nothing?,
     ): IrElement {
-        if (isProceedCall(expression)) return proceedReplacement()
+        if (isProceedCall(expression)) return buildProceedReplacement()
+        replaceCallTargetSlot(expression)?.let { slot ->
+            val local = slotToLocal[slot] ?: return super.visitCall(expression, data)
+            val valueArg = replaceCallValue(expression)
+                ?.transform(this, null) as? IrExpression
+                ?: return super.visitCall(expression, data)
+            return builder.irSet(local.symbol, valueArg)
+        }
         return super.visitCall(expression, data)
     }
 
@@ -190,8 +230,6 @@ private class AroundSubstitutionTransformer(
         expression: IrReturn,
         data: Nothing?,
     ): IrExpression {
-        // Returns that target the original lambda are retargeted to the target
-        // function so their value escapes both the lambda and the target.
         if (expression.returnTargetSymbol == lambdaFunction.symbol) {
             val newValue = expression.value.transform(this, null)
             return builder.irReturn(newValue)
@@ -199,10 +237,87 @@ private class AroundSubstitutionTransformer(
         return super.visitReturn(expression, data)
     }
 
+    /**
+     * Builds a fresh clone of the target's original return-value expression
+     * with target-parameter reads rebound to the matching local variables,
+     * so any `replace*`-induced override state flows in.
+     */
+    private fun buildProceedReplacement(): IrExpression {
+        val clone = originalReturnValue.deepCopyWithSymbols(initialParent = target)
+        clone.transformChildren(
+            SlotRefToLocalTransformer(builder, slotToLocal),
+            null,
+        )
+        return clone
+    }
+
     private fun isProceedCall(call: IrCall): Boolean {
         val callee = call.symbol.owner
         if (callee.name != AspectKAnnotations.PROCEED_NAME) return false
         val owner = callee.parentClassOrNull ?: return false
         return owner.kotlinFqName == AspectKAnnotations.AROUND_SCOPE_FQ_NAME
+    }
+
+    /**
+     * If [call] is a recognised `AroundScope.replace*` invocation with a
+     * constant slot identifier that resolves to a target parameter, returns
+     * that target parameter. Returns `null` otherwise.
+     */
+    private fun replaceCallTargetSlot(call: IrCall): IrValueParameter? {
+        val callee = call.symbol.owner
+        val owner = callee.parentClassOrNull ?: return null
+        if (owner.kotlinFqName != AspectKAnnotations.AROUND_SCOPE_FQ_NAME) return null
+        return when (callee.name.asString()) {
+            "replaceDispatchReceiver" ->
+                target.parameters.firstOrNull { it.kind == IrParameterKind.DispatchReceiver }
+            "replaceExtensionReceiver" ->
+                target.parameters.firstOrNull { it.kind == IrParameterKind.ExtensionReceiver }
+            "replaceValueParameter" ->
+                resolveSlotByConstArg(call, target.parameters.filter { it.kind == IrParameterKind.Regular })
+            "replaceContextParameter" ->
+                resolveSlotByConstArg(call, target.parameters.filter { it.kind == IrParameterKind.Context })
+            else -> null
+        }
+    }
+
+    private fun resolveSlotByConstArg(
+        call: IrCall,
+        candidates: List<IrValueParameter>,
+    ): IrValueParameter? {
+        // arguments layout: [dispatchReceiver, slotKey, value]
+        val keyArg = call.arguments.getOrNull(1) as? IrConst ?: return null
+        return when (val key = keyArg.value) {
+            is Int -> candidates.getOrNull(key)
+            is String -> candidates.firstOrNull { it.name.asString() == key }
+            else -> null
+        }
+    }
+
+    private fun replaceCallValue(call: IrCall): IrExpression? = call.arguments.getOrNull(2)
+}
+
+/**
+ * Rewrites `IrGetValue` reads of target parameter slots into reads of their
+ * corresponding local variables. Used inside the cloned original return-value
+ * expression so `proceed()` picks up the override state.
+ */
+private class SlotRefToLocalTransformer(
+    private val builder: DeclarationIrBuilder,
+    private val slotToLocal: Map<IrValueParameter, IrVariable>,
+) : IrTransformer<Nothing?>() {
+    override fun visitElement(
+        element: IrElement,
+        data: Nothing?,
+    ): IrElement {
+        element.transformChildren(this, null)
+        return element
+    }
+
+    override fun visitGetValue(
+        expression: IrGetValue,
+        data: Nothing?,
+    ): IrExpression {
+        val local = slotToLocal[expression.symbol.owner]
+        return if (local != null) builder.irGet(local) else expression
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
@@ -1,0 +1,208 @@
+package com.github.kitakkun.aspectk.compiler.backend.transformer
+
+import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import com.github.kitakkun.aspectk.compiler.backend.analyzer.AdviceMetadata
+import com.github.kitakkun.aspectk.compiler.backend.analyzer.Binding
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irReturn
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.expressions.IrBlockBody
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.expressions.IrGetValue
+import org.jetbrains.kotlin.ir.expressions.IrReturn
+import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
+import org.jetbrains.kotlin.ir.util.kotlinFqName
+import org.jetbrains.kotlin.ir.util.parentClassOrNull
+import org.jetbrains.kotlin.ir.util.primaryConstructor
+import org.jetbrains.kotlin.ir.visitors.IrTransformer
+
+/**
+ * Phase 3.3a `@Around` advice weaver (minimum-viable scope).
+ *
+ * For each `(target, around-advice)` match, this weaver:
+ *
+ * 1. Extracts the lambda body from the advice's `interceptableAdvice<R> { ... }`
+ *    invocation.
+ * 2. Deep-clones the lambda body so each target site gets an independent copy.
+ * 3. Inside the cloned body, rewrites:
+ *    - References to advice binding parameters into `IrGetValue` reads of the
+ *      target's matching slot.
+ *    - Calls to `AroundScope.proceed()` into a fresh clone of the target's
+ *      original return-value expression.
+ *    - `IrReturn`s that targeted the lambda into `IrReturn`s targeting the
+ *      target function (so the value escapes both the lambda and the target).
+ * 4. Replaces the target's body with the substituted block.
+ *
+ * Constraints carried by this minimum-viable cut:
+ *
+ * - The target's body must be a single `return <expr>` (`IrBlockBody` whose
+ *   sole statement is an `IrReturn`). Multi-statement bodies and
+ *   `IrExpressionBody` are deferred.
+ * - The aspect class must have a no-arg primary constructor.
+ * - The `replace*` family on `AroundScope` is left untransformed; calling any
+ *   of them at runtime throws via the stub in `aspectk-core`. Phase 3.3b
+ *   wires them up.
+ *
+ * The advice function itself is left untouched — the lambda body is cloned
+ * out of it and used as a template.
+ */
+internal class AroundAdviceWeaver(
+    private val pluginContext: IrPluginContext,
+) {
+    fun weave(
+        target: IrSimpleFunction,
+        aspectClass: IrClass,
+        advice: AdviceMetadata,
+    ): Boolean {
+        val ctor = aspectClass.primaryConstructor ?: return false
+        if (ctor.parameters.isNotEmpty()) return false
+
+        val adviceFn = advice.function
+        val lambdaFn = findAdviceLambda(adviceFn) ?: return false
+        val adviceLambdaBody = lambdaFn.body as? IrBlockBody ?: return false
+
+        val originalReturnValue = singleReturnValue(target) ?: return false
+
+        val paramSubst = buildParameterSubstitution(advice.bindings, target)
+
+        val clonedBody = adviceLambdaBody.deepCopyWithSymbols(initialParent = target)
+        val builder = DeclarationIrBuilder(
+            pluginContext,
+            target.symbol,
+            target.startOffset,
+            target.endOffset,
+        )
+        val substitution = AroundSubstitutionTransformer(
+            builder = builder,
+            paramSubst = paramSubst,
+            proceedReplacement = { originalReturnValue.deepCopyWithSymbols(initialParent = target) },
+            lambdaFunction = lambdaFn,
+            target = target,
+        )
+        clonedBody.transformChildren(substitution, null)
+
+        target.body = builder.irBlockBody {
+            for (stmt in clonedBody.statements) +stmt
+        }
+        return true
+    }
+
+    private fun findAdviceLambda(adviceFn: IrSimpleFunction): IrFunction? {
+        val body = adviceFn.body as? IrBlockBody ?: return null
+        val ret = body.statements.singleOrNull() as? IrReturn ?: return null
+        val call = ret.value as? IrCall ?: return null
+        val callee = call.symbol.owner
+        if (callee.parentClassOrNull != null) return null
+        if (callee.kotlinFqName != AspectKAnnotations.INTERCEPTABLE_ADVICE_FQ_NAME) return null
+        val lambdaArg = call.arguments.firstOrNull { it is IrFunctionExpression } as? IrFunctionExpression
+            ?: return null
+        return lambdaArg.function
+    }
+
+    private fun singleReturnValue(target: IrSimpleFunction): IrExpression? {
+        val body = target.body as? IrBlockBody ?: return null
+        val ret = body.statements.singleOrNull() as? IrReturn ?: return null
+        return ret.value
+    }
+
+    private fun buildParameterSubstitution(
+        bindings: List<Binding>,
+        target: IrSimpleFunction,
+    ): Map<IrValueParameter, IrValueParameter> {
+        val map = mutableMapOf<IrValueParameter, IrValueParameter>()
+        for (binding in bindings) {
+            val targetSlot = findTargetSlot(binding, target) ?: continue
+            map[binding.adviceParameter] = targetSlot
+        }
+        return map
+    }
+
+    private fun findTargetSlot(
+        binding: Binding,
+        target: IrSimpleFunction,
+    ): IrValueParameter? =
+        when (binding) {
+            is Binding.DispatchReceiver ->
+                target.parameters.firstOrNull { it.kind == IrParameterKind.DispatchReceiver }
+            is Binding.ExtensionReceiver ->
+                target.parameters.firstOrNull { it.kind == IrParameterKind.ExtensionReceiver }
+            is Binding.ValueParameter -> {
+                val regulars = target.parameters.filter { it.kind == IrParameterKind.Regular }
+                when {
+                    binding.index != null -> regulars.getOrNull(binding.index)
+                    binding.name != null -> regulars.firstOrNull { it.name.asString() == binding.name }
+                    else -> null
+                }
+            }
+            is Binding.ContextParameter -> {
+                val contexts = target.parameters.filter { it.kind == IrParameterKind.Context }
+                when {
+                    binding.index != null -> contexts.getOrNull(binding.index)
+                    binding.name != null -> contexts.firstOrNull { it.name.asString() == binding.name }
+                    else -> null
+                }
+            }
+        }
+}
+
+private class AroundSubstitutionTransformer(
+    private val builder: DeclarationIrBuilder,
+    private val paramSubst: Map<IrValueParameter, IrValueParameter>,
+    private val proceedReplacement: () -> IrExpression,
+    private val lambdaFunction: IrFunction,
+    private val target: IrSimpleFunction,
+) : IrTransformer<Nothing?>() {
+    override fun visitElement(
+        element: IrElement,
+        data: Nothing?,
+    ): IrElement {
+        element.transformChildren(this, null)
+        return element
+    }
+
+    override fun visitGetValue(
+        expression: IrGetValue,
+        data: Nothing?,
+    ): IrExpression {
+        val targetSlot = paramSubst[expression.symbol.owner]
+        return if (targetSlot != null) builder.irGet(targetSlot) else expression
+    }
+
+    override fun visitCall(
+        expression: IrCall,
+        data: Nothing?,
+    ): IrElement {
+        if (isProceedCall(expression)) return proceedReplacement()
+        return super.visitCall(expression, data)
+    }
+
+    override fun visitReturn(
+        expression: IrReturn,
+        data: Nothing?,
+    ): IrExpression {
+        // Returns that target the original lambda are retargeted to the target
+        // function so their value escapes both the lambda and the target.
+        if (expression.returnTargetSymbol == lambdaFunction.symbol) {
+            val newValue = expression.value.transform(this, null)
+            return builder.irReturn(newValue)
+        }
+        return super.visitReturn(expression, data)
+    }
+
+    private fun isProceedCall(call: IrCall): Boolean {
+        val callee = call.symbol.owner
+        if (callee.name != AspectKAnnotations.PROCEED_NAME) return false
+        val owner = callee.parentClassOrNull ?: return false
+        return owner.kotlinFqName == AspectKAnnotations.AROUND_SCOPE_FQ_NAME
+    }
+}

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
@@ -262,6 +262,15 @@ private class AroundSubstitutionTransformer(
      * If [call] is a recognised `AroundScope.replace*` invocation with a
      * constant slot identifier that resolves to a target parameter, returns
      * that target parameter. Returns `null` otherwise.
+     *
+     * Caveat: returning null here can mean either "not a `replace*` call at
+     * all" or "a `replace*` call whose slot key isn't a compile-time
+     * constant". The visitCall caller treats both as fall-through; the
+     * latter case leaves the original `AroundScope.replace*` call in place,
+     * which would crash at runtime via the `aspectk-core` stub. A dedicated
+     * UNRESOLVED_REPLACE_SLOT diagnostic is tracked under task #26 (FIR
+     * pointcut-completeness check), where the necessary diagnostic-factory
+     * plumbing already lives.
      */
     private fun replaceCallTargetSlot(call: IrCall): IrValueParameter? {
         val callee = call.symbol.owner

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
@@ -47,6 +47,8 @@ internal class AspectKTransformer(
     private val pluginContext: IrPluginContext,
     private val aspects: List<AspectMetadata>,
 ) : IrTransformer<Nothing?>() {
+    private val aroundWeaver = AroundAdviceWeaver(pluginContext)
+
     override fun visitElement(
         element: IrElement,
         data: Nothing?,
@@ -80,7 +82,7 @@ internal class AspectKTransformer(
         when (advice.kind) {
             AdviceKind.BEFORE -> applyBefore(target, aspectClass, advice)
             AdviceKind.AFTER -> applyAfter(target, aspectClass, advice)
-            AdviceKind.AROUND -> Unit // Phase 3.3
+            AdviceKind.AROUND -> aroundWeaver.weave(target, aspectClass, advice)
         }
     }
 

--- a/aspectk-core/src/commonMain/kotlin/com/github/kitakkun/aspectk/core/AroundScope.kt
+++ b/aspectk-core/src/commonMain/kotlin/com/github/kitakkun/aspectk/core/AroundScope.kt
@@ -1,0 +1,57 @@
+package com.github.kitakkun.aspectk.core
+
+/**
+ * Scope receiver for the body of an `@Around` advice.
+ *
+ * Inside the lambda passed to [interceptableAdvice], the AspectK compiler
+ * plugin rewrites calls to [proceed] into an invocation of the matched
+ * target method. The class itself is never instantiated at runtime — the
+ * member functions all throw if the compiler plugin is not on the classpath.
+ */
+@Suppress("UNUSED_PARAMETER")
+class AroundScope<R> internal constructor() {
+    /**
+     * Invokes the matched target method with the currently-set bindings and
+     * returns its result.
+     *
+     * Rewritten by the AspectK compiler plugin; calling this outside an
+     * `@Around` advice body is an error.
+     */
+    fun proceed(): R = throwOutsidePluginContext()
+
+    /** Replaces the N-th value parameter for the next [proceed] call. */
+    fun replaceValueParameter(index: Int, value: Any?): Unit = throwOutsidePluginContext()
+
+    /** Replaces the named value parameter for the next [proceed] call. */
+    fun replaceValueParameter(name: String, value: Any?): Unit = throwOutsidePluginContext()
+
+    /** Replaces the dispatch receiver for the next [proceed] call. */
+    fun replaceDispatchReceiver(value: Any?): Unit = throwOutsidePluginContext()
+
+    /** Replaces the extension receiver for the next [proceed] call. */
+    fun replaceExtensionReceiver(value: Any?): Unit = throwOutsidePluginContext()
+
+    /** Replaces the N-th context parameter for the next [proceed] call. */
+    fun replaceContextParameter(index: Int, value: Any?): Unit = throwOutsidePluginContext()
+
+    /** Replaces the named context parameter for the next [proceed] call. */
+    fun replaceContextParameter(name: String, value: Any?): Unit = throwOutsidePluginContext()
+
+    private fun throwOutsidePluginContext(): Nothing =
+        error("AspectK: this function only has meaning inside an @Around advice's interceptableAdvice { ... } block.")
+}
+
+/**
+ * Marker DSL builder for the body of an `@Around` advice.
+ *
+ * The lambda's receiver exposes `proceed()` and the `replace*` family of
+ * override functions. The AspectK compiler plugin rewrites every advice site
+ * so that this call is replaced with the lambda body inlined into the
+ * matched target, with `proceed()` standing in for the original target body.
+ *
+ * Outside of an `@Around` advice this function throws — it should never run
+ * unaltered.
+ */
+@Suppress("UNUSED_PARAMETER")
+fun <R> interceptableAdvice(block: AroundScope<R>.() -> R): R =
+    error("AspectK: interceptableAdvice { ... } only has meaning inside an @Around advice body.")

--- a/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/GreetingTracer.kt
+++ b/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/GreetingTracer.kt
@@ -1,31 +1,25 @@
 package com.github.kitakkun.aspectk.test
 
-import com.github.kitakkun.aspectk.annotations.After
+import com.github.kitakkun.aspectk.annotations.Around
 import com.github.kitakkun.aspectk.annotations.Aspect
-import com.github.kitakkun.aspectk.annotations.Before
 import com.github.kitakkun.aspectk.annotations.ClassName
 import com.github.kitakkun.aspectk.annotations.DispatchReceiver
 import com.github.kitakkun.aspectk.annotations.MethodName
 import com.github.kitakkun.aspectk.annotations.ValueParameter
+import com.github.kitakkun.aspectk.core.interceptableAdvice
 
 @Aspect
 class GreetingTracer {
-    @Before
+    @Around
     @ClassName("Greeter")
     @MethodName("greet")
-    fun beforeGreet(
+    fun aroundGreet(
         @DispatchReceiver greeter: Greeter,
         @ValueParameter(0) name: String,
-    ) {
-        println("[before] $greeter.greet($name)")
-    }
-
-    @After
-    @ClassName("Greeter")
-    @MethodName("greet")
-    fun afterGreet(
-        @ValueParameter(0) name: String,
-    ) {
-        println("[after] greeted $name")
+    ): String = interceptableAdvice {
+        println("[around-before] $greeter.greet($name)")
+        val r = proceed()
+        println("[around-after] returned $r")
+        r
     }
 }

--- a/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/GreetingTracer.kt
+++ b/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/GreetingTracer.kt
@@ -18,6 +18,7 @@ class GreetingTracer {
         @ValueParameter(0) name: String,
     ): String = interceptableAdvice {
         println("[around-before] $greeter.greet($name)")
+        replaceValueParameter(0, name.uppercase())
         val r = proceed()
         println("[around-after] returned $r")
         r


### PR DESCRIPTION
## Summary

Phase 3.3 of the v1 roadmap, stacked on #21 (`feat/v1-phase3.2-after`).

Implements `` `@Around` `` advice end-to-end on top of the Phase 3.1 binding mechanism. The advice body is written as `= interceptableAdvice { … proceed() … }`; the IR transformer inlines the lambda into each matched target, substituting the binding-parameter reads, the `proceed()` calls, and the `replace*` family.

Lands in two commits inside this PR:

- **3.3a** — runtime API (`AroundScope<R>` + `interceptableAdvice`) and the basic inlining of the lambda body with `proceed()` substituted by the target's original return expression.
- **3.3b** — `replace*` override semantics via slot-keyed mutable locals; the advice body, the override assignment, and the cloned proceed expression all share the same local per bound slot.

### Runtime API (`aspectk-core`)

```kotlin
class AroundScope<R> internal constructor() {
    fun proceed(): R                                        // stub; rewritten by plugin
    fun replaceValueParameter(index: Int, value: Any?)
    fun replaceValueParameter(name: String, value: Any?)
    fun replaceDispatchReceiver(value: Any?)
    fun replaceExtensionReceiver(value: Any?)
    fun replaceContextParameter(index: Int, value: Any?)
    fun replaceContextParameter(name: String, value: Any?)
}

fun <R> interceptableAdvice(block: AroundScope<R>.() -> R): R = error("...")
```

All members throw at runtime if the AspectK compiler plugin is not on the classpath.

### IR transformation (`backend/transformer/AroundAdviceWeaver`)

Per `(target, around-advice)` match:

1. Extract the lambda body from `interceptableAdvice<R>(lambda)` in the advice.
2. Declare one mutable local per bound slot, initialised from the target's matching parameter (`__<slotName>`).
3. Deep-clone the lambda body and rewrite, with the substitution transformer:
   - Advice binding parameter reads → local-variable reads.
   - `AroundScope.replace*(slotKey, value)` → `IrSetValue` on the matching local. Slot keys must be literal `IrConst<Int>` / `IrConst<String>`.
   - `AroundScope.proceed()` → a fresh clone of the target's original return-value expression with target-parameter reads remapped to local-variable reads, so override state flows into the call.
   - `IrReturn`s targeting the lambda → `IrReturn`s targeting the target function.
4. Compose the new target body: local declarations followed by the substituted lambda block.

### Test sample (`test/`)

```kotlin
@Aspect
class GreetingTracer {
    @Around @ClassName("Greeter") @MethodName("greet")
    fun aroundGreet(
        @DispatchReceiver greeter: Greeter,
        @ValueParameter(0) name: String,
    ): String = interceptableAdvice {
        println("[around-before] \$greeter.greet(\$name)")
        replaceValueParameter(0, name.uppercase())
        val r = proceed()
        println("[around-after] returned \$r")
        r
    }
}
```

Running `MainKt` prints:

```
[around-before] com.github.kitakkun.aspectk.test.Greeter@…greet(world)
[around-after] returned hello WORLD
hello WORLD
```

— confirming the binding reads (`greeter`, `name`) carry the target's actual values, `replaceValueParameter` writes through to the local that `proceed()` will see, and the result flows back to the caller.

### Not in scope for this PR

- **FIR shape check** that an `@Around` body is exactly `= interceptableAdvice { … }`. Today a malformed body falls through `applyAround` and the target is left unwoven. Tracked as a follow-up under the same Phase 3.3 task.
- **Bind-first FIR rule.** Currently enforced indirectly: only bound slots get a local, so unbound `replace*` calls fall through to the runtime stub. A dedicated FIR checker that rejects them ahead of IR time is a follow-up.
- **Type compatibility check** between override value and binding declared type.
- **Multi-statement / `IrExpressionBody` targets.** Only single-`return` body shapes are wrapped today.
- **Multi-kind composition** (`@Around` together with `@Before` / `@After` on the same target) is undefined; `@Around` replaces the body.

## Test plan

- [x] `./gradlew build` — green.
- [x] Manually ran the compiled `MainKt` with and without the `replaceValueParameter` call; the override is reflected in the proceed result.
- [ ] (Deferred to Phase 7) compiler-test-framework cases that exercise proceed-without-replace, replace + proceed, multiple proceeds, and the malformed-body diagnostic.
