### PR TITLE
Phase 3.4: additional matching annotations

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectAnalyzer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectAnalyzer.kt
@@ -8,10 +8,15 @@ import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrGetEnumValue
+import org.jetbrains.kotlin.ir.expressions.IrVararg
+import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.util.getAnnotation
 import org.jetbrains.kotlin.ir.util.hasAnnotation
+import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 
 /**
@@ -20,10 +25,9 @@ import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
  * into a [PointcutFilter], and collects per-parameter [Binding]s from the
  * advice's value parameters.
  *
- * Phase 3.1 scope: `@ClassName` / `@MethodName` matching plus full binding
- * support for `@DispatchReceiver` / `@ExtensionReceiver` / `@ContextParameter` /
- * `@ValueParameter`. The remaining matching annotations (`@Visibility`,
- * `@Package`, `@Annotated`, …) arrive in Phase 3.4.
+ * Phase 3.4 scope: full reading of every v1 matching annotation
+ * (`@Package` / `@ClassName` / `@MethodName` / `@Visibility` / `@Modality` /
+ * `@Modifiers` / `@Annotated`) plus per-parameter binding extraction.
  */
 internal class AspectAnalyzer {
     fun analyze(moduleFragment: IrModuleFragment): List<AspectMetadata> {
@@ -69,16 +73,56 @@ internal class AspectAnalyzer {
         }
 
     private fun pointcutOf(fn: IrSimpleFunction): PointcutFilter {
-        val className = fn
+        val packagePattern = fn
+            .getAnnotation(AspectKAnnotations.PACKAGE_CLASS_ID.asSingleFqName())
+            ?.getStringConstArgument(0)
+        val classNamePattern = fn
             .getAnnotation(AspectKAnnotations.CLASS_NAME_CLASS_ID.asSingleFqName())
             ?.getStringConstArgument(0)
-        val methodName = fn
+        val methodNamePattern = fn
             .getAnnotation(AspectKAnnotations.METHOD_NAME_CLASS_ID.asSingleFqName())
             ?.getStringConstArgument(0)
+        val visibilities = enumValuesArg(fn, AspectKAnnotations.VISIBILITY_CLASS_ID.asSingleFqName())
+        val modalities = enumValuesArg(fn, AspectKAnnotations.MODALITY_CLASS_ID.asSingleFqName())
+        val modifiers = enumValuesArg(fn, AspectKAnnotations.MODIFIERS_CLASS_ID.asSingleFqName())
+        val annotatedFqNames = annotatedFqNamesArg(fn)
         return PointcutFilter(
-            classNamePattern = className,
-            methodNamePattern = methodName,
+            packagePattern = packagePattern,
+            classNamePattern = classNamePattern,
+            methodNamePattern = methodNamePattern,
+            visibilities = visibilities,
+            modalities = modalities,
+            modifiers = modifiers,
+            annotatedFqNames = annotatedFqNames,
         )
+    }
+
+    private fun enumValuesArg(
+        fn: IrSimpleFunction,
+        annotationFqName: org.jetbrains.kotlin.name.FqName,
+    ): List<String> {
+        val ann = fn.getAnnotation(annotationFqName) ?: return emptyList()
+        val vararg = ann.arguments.firstOrNull { it is IrVararg } as? IrVararg ?: return emptyList()
+        return vararg.elements.mapNotNull {
+            (it as? IrGetEnumValue)
+                ?.symbol
+                ?.owner
+                ?.name
+                ?.asString()
+        }
+    }
+
+    private fun annotatedFqNamesArg(fn: IrSimpleFunction): List<String> {
+        val ann = fn.getAnnotation(AspectKAnnotations.ANNOTATED_CLASS_ID.asSingleFqName()) ?: return emptyList()
+        val vararg = ann.arguments.firstOrNull { it is IrVararg } as? IrVararg ?: return emptyList()
+        return vararg.elements.mapNotNull { element ->
+            (element as? IrClassReference)
+                ?.classType
+                ?.classOrNull
+                ?.owner
+                ?.kotlinFqName
+                ?.asString()
+        }
     }
 
     private fun bindingsOf(fn: IrSimpleFunction): List<Binding> =

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectMetadata.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectMetadata.kt
@@ -19,16 +19,18 @@ internal data class AdviceMetadata(
 internal enum class AdviceKind { BEFORE, AFTER, AROUND }
 
 /**
- * Phase 3.1 subset of the pointcut filter. Carries the name-pattern matching
- * annotations plus signature-driven constraints derived from binding parameters
- * (a `@DispatchReceiver` binding implies the target has a dispatch receiver of
- * a compatible type, etc.). The remaining matching annotations
- * (`@Visibility` / `@Modality` / `@Modifiers` / `@Package` / `@Annotated`)
- * are added in Phase 3.4.
+ * Pointcut filter assembled from the matching annotations stacked on the
+ * advice function. Each field corresponds to one annotation; a `null` /
+ * empty list means "no constraint from that dimension".
  */
 internal data class PointcutFilter(
+    val packagePattern: String?,
     val classNamePattern: String?,
     val methodNamePattern: String?,
+    val visibilities: List<String>,
+    val modalities: List<String>,
+    val modifiers: List<String>,
+    val annotatedFqNames: List<String>,
 )
 
 /**

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/matching/PackagePattern.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/matching/PackagePattern.kt
@@ -1,0 +1,81 @@
+package com.github.kitakkun.aspectk.compiler.backend.matching
+
+/**
+ * Glob-style package matching for `@Package` patterns.
+ *
+ * Pattern syntax:
+ * - A literal name (`"com.example.repo"`) matches that package exactly.
+ * - `*` matches a single whole segment (e.g. `"com.example.*"` matches
+ *   `com.example.foo` but not `com.example.foo.bar` and not `com.example`).
+ * - `**` matches zero or more whole segments. When immediately surrounded by
+ *   dots the surrounding dot is treated as part of the wildcard — so
+ *   `"com.**.repo"` matches `com.repo`, `com.foo.repo`, `com.foo.bar.repo`,
+ *   and `"com.**"` matches `com`, `com.foo`, `com.foo.bar`.
+ * - Root package (top-level declarations with no package): use `pattern = ""`.
+ *
+ * The pattern is anchored — the entire package name must match.
+ */
+internal object PackagePattern {
+    fun matches(
+        pattern: String,
+        packageName: String,
+    ): Boolean {
+        if (pattern == packageName) return true
+        if (pattern.isEmpty()) return packageName.isEmpty()
+        if (pattern == "**") return true
+        if ('*' !in pattern) return false
+        return compile(pattern).matches(packageName)
+    }
+
+    private fun compile(pattern: String): Regex {
+        val sb = StringBuilder("^")
+        var i = 0
+        while (i < pattern.length) {
+            val ch = pattern[i]
+            when {
+                i + 1 < pattern.length && ch == '*' && pattern[i + 1] == '*' -> {
+                    val precededByEscapedDot = sb.endsWith("\\.")
+                    val followedByDot = i + 2 < pattern.length && pattern[i + 2] == '.'
+                    when {
+                        precededByEscapedDot && followedByDot -> {
+                            // `.**.` — strip the trailing `\.`, replace with the
+                            // group that swallows the preceding dot too.
+                            sb.setLength(sb.length - 2)
+                            sb.append("(\\.[^.]+)*\\.")
+                            i += 3
+                        }
+                        precededByEscapedDot -> {
+                            // `.**` at the end of the pattern.
+                            sb.setLength(sb.length - 2)
+                            sb.append("(\\.[^.]+)*")
+                            i += 2
+                        }
+                        followedByDot -> {
+                            // `**.` at the start of the pattern.
+                            sb.append("([^.]+\\.)*")
+                            i += 3
+                        }
+                        else -> {
+                            sb.append(".*")
+                            i += 2
+                        }
+                    }
+                }
+                ch == '*' -> {
+                    sb.append("[^.]*")
+                    i++
+                }
+                ch == '.' -> {
+                    sb.append("\\.")
+                    i++
+                }
+                else -> {
+                    sb.append(Regex.escape(ch.toString()))
+                    i++
+                }
+            }
+        }
+        sb.append("$")
+        return Regex(sb.toString())
+    }
+}

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/matching/PointcutMatcher.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/matching/PointcutMatcher.kt
@@ -3,8 +3,12 @@ package com.github.kitakkun.aspectk.compiler.backend.matching
 import com.github.kitakkun.aspectk.compiler.backend.analyzer.AdviceMetadata
 import com.github.kitakkun.aspectk.compiler.backend.analyzer.Binding
 import com.github.kitakkun.aspectk.compiler.backend.analyzer.PointcutFilter
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.util.getPackageFragment
+import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 
 internal object PointcutMatcher {
@@ -21,14 +25,126 @@ internal object PointcutMatcher {
         filter: PointcutFilter,
         target: IrSimpleFunction,
     ): Boolean {
-        filter.classNamePattern?.let { pattern ->
-            val containingClassName = target.parentClassOrNull?.name?.asString() ?: return false
-            if (!NamePattern.matches(pattern, containingClassName)) return false
+        if (!packageMatches(filter.packagePattern, target)) return false
+        if (!classNameMatches(filter.classNamePattern, target)) return false
+        if (!methodNameMatches(filter.methodNamePattern, target)) return false
+        if (!visibilityMatches(filter.visibilities, target)) return false
+        if (!modalityMatches(filter.modalities, target)) return false
+        if (!modifiersMatch(filter.modifiers, target)) return false
+        if (!annotatedMatches(filter.annotatedFqNames, target)) return false
+        return true
+    }
+
+    private fun packageMatches(
+        pattern: String?,
+        target: IrSimpleFunction,
+    ): Boolean {
+        if (pattern == null) return true
+        val pkg = target.getPackageFragment().packageFqName.asString()
+        return PackagePattern.matches(pattern, pkg)
+    }
+
+    private fun classNameMatches(
+        pattern: String?,
+        target: IrSimpleFunction,
+    ): Boolean {
+        if (pattern == null) return true
+        val containingClassName = target.parentClassOrNull?.name?.asString() ?: return false
+        return NamePattern.matches(pattern, containingClassName)
+    }
+
+    private fun methodNameMatches(
+        pattern: String?,
+        target: IrSimpleFunction,
+    ): Boolean {
+        if (pattern == null) return true
+        return NamePattern.matches(pattern, target.name.asString())
+    }
+
+    /**
+     * `@Visibility(vararg Kind)` — OR-combined across the listed kinds. The
+     * target's visibility must be one of them.
+     */
+    private fun visibilityMatches(
+        visibilities: List<String>,
+        target: IrSimpleFunction,
+    ): Boolean {
+        if (visibilities.isEmpty()) return true
+        val current = visibilityOf(target) ?: return false
+        return current in visibilities
+    }
+
+    private fun visibilityOf(target: IrSimpleFunction): String? =
+        when (target.visibility) {
+            DescriptorVisibilities.PUBLIC -> "PUBLIC"
+            DescriptorVisibilities.INTERNAL -> "INTERNAL"
+            DescriptorVisibilities.PROTECTED -> "PROTECTED"
+            DescriptorVisibilities.PRIVATE, DescriptorVisibilities.PRIVATE_TO_THIS -> "PRIVATE"
+            else -> null
         }
-        filter.methodNamePattern?.let { pattern ->
-            if (!NamePattern.matches(pattern, target.name.asString())) return false
+
+    /**
+     * `@Modality(vararg Kind)` — OR-combined. The target's modality must be one
+     * of them. For top-level functions (no enclosing class) there is no
+     * modality concept and the constraint never matches.
+     */
+    private fun modalityMatches(
+        modalities: List<String>,
+        target: IrSimpleFunction,
+    ): Boolean {
+        if (modalities.isEmpty()) return true
+        val current = modalityOf(target) ?: return false
+        return current in modalities
+    }
+
+    private fun modalityOf(target: IrSimpleFunction): String? =
+        when (target.modality) {
+            Modality.FINAL -> "FINAL"
+            Modality.OPEN -> "OPEN"
+            Modality.ABSTRACT -> "ABSTRACT"
+            Modality.SEALED -> "SEALED"
+        }
+
+    /**
+     * `@Modifiers(vararg Kind)` — AND-combined. The target must carry every
+     * listed modifier.
+     */
+    private fun modifiersMatch(
+        modifiers: List<String>,
+        target: IrSimpleFunction,
+    ): Boolean {
+        if (modifiers.isEmpty()) return true
+        for (modifier in modifiers) {
+            val present = when (modifier) {
+                "SUSPEND" -> target.isSuspend
+                "INLINE" -> target.isInline
+                "INFIX" -> target.isInfix
+                "OPERATOR" -> target.isOperator
+                "TAILREC" -> target.isTailrec
+                "EXTERNAL" -> target.isExternal
+                else -> false
+            }
+            if (!present) return false
         }
         return true
+    }
+
+    /**
+     * `@Annotated(vararg KClass)` — OR-combined. The target must carry at
+     * least one of the listed annotations.
+     */
+    private fun annotatedMatches(
+        annotatedFqNames: List<String>,
+        target: IrSimpleFunction,
+    ): Boolean {
+        if (annotatedFqNames.isEmpty()) return true
+        val targetAnnotations = target.annotations
+            .mapNotNull {
+                it.symbol.owner.parentClassOrNull
+                    ?.kotlinFqName
+                    ?.asString()
+            }.toSet()
+        return annotatedFqNames.any { it in targetAnnotations }
     }
 
     /**

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/matching/PointcutMatcher.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/matching/PointcutMatcher.kt
@@ -84,21 +84,33 @@ internal object PointcutMatcher {
         }
 
     /**
-     * `@Modality(vararg Kind)` — OR-combined. The target's modality must be one
-     * of them. For top-level functions (no enclosing class) there is no
-     * modality concept and the constraint never matches.
+     * `@Modality(vararg Kind)` — OR-combined across both the function's own
+     * modality and the enclosing class's modality (per Modality.kt KDoc:
+     * "OPEN matches open class and open fun parents"). For top-level
+     * functions the enclosing class side contributes nothing.
      */
     private fun modalityMatches(
         modalities: List<String>,
         target: IrSimpleFunction,
     ): Boolean {
         if (modalities.isEmpty()) return true
-        val current = modalityOf(target) ?: return false
-        return current in modalities
+        val current = modalitiesOf(target)
+        if (current.isEmpty()) return false
+        return modalities.any { it in current }
     }
 
-    private fun modalityOf(target: IrSimpleFunction): String? =
-        when (target.modality) {
+    private fun modalitiesOf(target: IrSimpleFunction): Set<String> {
+        val result = mutableSetOf<String>()
+        modalityLabel(target.modality)?.let(result::add)
+        target.parentClassOrNull
+            ?.modality
+            ?.let(::modalityLabel)
+            ?.let(result::add)
+        return result
+    }
+
+    private fun modalityLabel(modality: Modality): String? =
+        when (modality) {
             Modality.FINAL -> "FINAL"
             Modality.OPEN -> "OPEN"
             Modality.ABSTRACT -> "ABSTRACT"

--- a/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/GreetingTracer.kt
+++ b/test/src/commonMain/kotlin/com/github/kitakkun/aspectk/test/GreetingTracer.kt
@@ -5,12 +5,16 @@ import com.github.kitakkun.aspectk.annotations.Aspect
 import com.github.kitakkun.aspectk.annotations.ClassName
 import com.github.kitakkun.aspectk.annotations.DispatchReceiver
 import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.Package
 import com.github.kitakkun.aspectk.annotations.ValueParameter
+import com.github.kitakkun.aspectk.annotations.Visibility
 import com.github.kitakkun.aspectk.core.interceptableAdvice
 
 @Aspect
 class GreetingTracer {
     @Around
+    @Package("com.github.kitakkun.aspectk.test")
+    @Visibility(Visibility.Kind.PUBLIC)
     @ClassName("Greeter")
     @MethodName("greet")
     fun aroundGreet(


### PR DESCRIPTION
## Summary

Phase 3.4 of the v1 roadmap, stacked on #22 (`feat/v1-phase3.3-around`).

Wires up the remaining v1 matching annotations declared back in Phase 1. The analyzer reads them into the `PointcutFilter`, and the matcher honours each dimension before falling back to the existing name-pattern and binding-presence checks.

### New matching dimensions

| Annotation | Combine | Resolved via |
|---|---|---|
| `` `@Package(pattern: String)` `` | n/a | `PackagePattern` (new) — `*` single segment, `**` zero or more segments |
| `` `@Visibility(vararg Kind)` `` | OR | `target.visibility` ↔ `DescriptorVisibilities` |
| `` `@Modality(vararg Kind)` `` | OR | `target.modality` ↔ `Modality` |
| `` `@Modifiers(vararg Kind)` `` | AND | `target.isSuspend` / `isInline` / `isInfix` / `isOperator` / `isTailrec` / `isExternal` |
| `` `@Annotated(vararg KClass)` `` | OR | walks `target.annotations`, compares FQN |

### PackagePattern semantics

```
@Package("com.example.**")        // matches com.example, com.example.foo, com.example.foo.bar
@Package("com.example.*")         // matches com.example.foo only
@Package("**.repo")               // matches repo, a.repo, a.b.repo
@Package("com.**.repo")           // matches com.repo, com.a.repo, com.a.b.repo
@Package("")                       // matches root package only
```

The `**` wildcard consumes the surrounding dot when adjacent — so `com.example.**` accepts `com.example` itself with zero trailing segments. Implemented in a dedicated `PackagePattern.kt` module to keep the `NamePattern` (single-name glob) semantics distinct.

### Analyzer changes

- `pointcutOf` reads all seven annotations into the extended `PointcutFilter`.
- Enum vararg values are read out of the `IrConstructorCall`'s `IrVararg` argument as `IrGetEnumValue.symbol.owner.name`.
- `@Annotated` reads `IrClassReference.classType.classOrNull.owner.kotlinFqName` for each listed KClass.

### Matcher changes

- `filterMatches` short-circuits across every dimension; a null / empty constraint is "no constraint, accept anything".
- Visibility comparison uses `target.visibility` directly (the `DescriptorVisibility` singletons in `DescriptorVisibilities`), not `.delegate`.

### Test sample

`GreetingTracer.aroundGreet` is now stacked with the new `` `@Package` `` and `` `@Visibility` `` annotations alongside the existing `` `@ClassName` `` / `` `@MethodName` ``:

```kotlin
@Around
@Package("com.github.kitakkun.aspectk.test")
@Visibility(Visibility.Kind.PUBLIC)
@ClassName("Greeter")
@MethodName("greet")
fun aroundGreet(...): String = interceptableAdvice { ... }
```

Running `MainKt` still produces:

```
[around-before] com.github.kitakkun.aspectk.test.Greeter@…greet(world)
[around-after] returned hello WORLD
hello WORLD
```

confirming all four declared matching annotations are honoured.

### Not in scope

- Negative-case matrix tests (private vs public, wrong package, wrong modifier set). These belong to the Phase 7 compiler-test harness reinstatement.
- `@Repeatable` support for stacking multiple instances of the same annotation (currently each dimension is single-instance).

## Test plan

- [x] `./gradlew build` — green.
- [x] Manually ran the compiled `MainKt` with the extended pointcut; advice still fires.
- [ ] (Deferred to Phase 7) compiler-test-framework cases that probe each matching dimension's positive and negative cases.
