### PR TITLE
Phase 3.5: FIR-side matching + WOVEN_CALL_SITE diagnostic at advised call sites

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
@@ -6,7 +6,9 @@ import org.jetbrains.kotlin.diagnostics.error1
 import org.jetbrains.kotlin.diagnostics.error2
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.rendering.CommonRenderers
+import org.jetbrains.kotlin.diagnostics.warning1
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFunction
 
 object AspectKErrors : KtDiagnosticsContainer() {
@@ -21,6 +23,14 @@ object AspectKErrors : KtDiagnosticsContainer() {
 
     /** `@ValueParameter` / `@ContextParameter` must specify exactly one of `index` / `name`. */
     val INVALID_BINDING_ANNOTATION by error2<KtAnnotationEntry, String, String>()
+
+    /**
+     * A function call site is woven by an `@Around` / `@Before` / `@After`
+     * advice. Surfaces as a weak compiler diagnostic so IntelliJ shows an
+     * inline marker. The single argument is the woven advice's FQN + kind,
+     * e.g. `"GreetingTracer.aroundGreet (@Around)"`.
+     */
+    val WOVEN_CALL_SITE by warning1<KtElement, String>()
 
     override fun getRendererFactory(): BaseDiagnosticRendererFactory = AspectKDefaultMessages
 }
@@ -48,6 +58,11 @@ private object AspectKDefaultMessages : BaseDiagnosticRendererFactory() {
             AspectKErrors.INVALID_BINDING_ANNOTATION,
             "@{0}: {1}",
             CommonRenderers.STRING,
+            CommonRenderers.STRING,
+        )
+        map.put(
+            AspectKErrors.WOVEN_CALL_SITE,
+            "intercepted by {0}",
             CommonRenderers.STRING,
         )
     }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKFirCheckerExtension.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKFirCheckerExtension.kt
@@ -1,9 +1,15 @@
 package com.github.kitakkun.aspectk.compiler.fir.checker
 
+import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirExpressionChecker
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
+import org.jetbrains.kotlin.fir.extensions.predicate.LookupPredicate
 
 class AspectKFirCheckerExtension(
     session: FirSession,
@@ -14,5 +20,21 @@ class AspectKFirCheckerExtension(
             PointcutAnnotationChecker,
             BindingAnnotationChecker,
         )
+    }
+
+    override val expressionCheckers = object : ExpressionCheckers() {
+        override val functionCallCheckers: Set<FirExpressionChecker<FirFunctionCall>> = setOf(
+            WovenCallSiteChecker,
+        )
+    }
+
+    override fun FirDeclarationPredicateRegistrar.registerPredicates() {
+        register(ASPECT_LOOKUP)
+    }
+
+    companion object {
+        private val ASPECT_LOOKUP = LookupPredicate.create {
+            annotated(AspectKAnnotations.ASPECT_FQ_NAME)
+        }
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/WovenCallSiteChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/WovenCallSiteChecker.kt
@@ -1,0 +1,160 @@
+package com.github.kitakkun.aspectk.compiler.fir.checker
+
+import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirExpressionChecker
+import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
+import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
+import org.jetbrains.kotlin.fir.declarations.getStringArgument
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.extensions.predicate.LookupPredicate
+import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
+import org.jetbrains.kotlin.fir.references.toResolvedNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.name.ClassId
+
+/**
+ * Emits a weak [AspectKErrors.WOVEN_CALL_SITE] diagnostic at each function
+ * call whose callee is matched by at least one advice in the current session.
+ *
+ * Phase 3.5 over-approximates: only `@ClassName` / `@MethodName` patterns
+ * are honoured at FIR time. IR remains the authoritative weaver; an
+ * over-fired marker is acceptable for editor feedback.
+ *
+ * Aspect discovery uses the FIR predicate system (`LookupPredicate.annotated
+ * (@Aspect)`); the registrar registers the predicate so the session-wide
+ * annotation index includes `@Aspect`.
+ *
+ * Calls whose callee lives inside an `@Aspect` class are skipped — the IR
+ * weaver never targets those either.
+ */
+object WovenCallSiteChecker : FirExpressionChecker<FirFunctionCall>(MppCheckerKind.Common) {
+    private val ASPECT_LOOKUP: LookupPredicate = LookupPredicate.create {
+        annotated(AspectKAnnotations.ASPECT_FQ_NAME)
+    }
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(expression: FirFunctionCall) {
+        val session = context.session
+        val calleeSymbol = expression.calleeReference.toResolvedNamedFunctionSymbol() ?: return
+
+        // Skip calls into @Aspect classes (advice-internal calls) and skip
+        // calls to advice functions themselves.
+        if (isInsideAspectClass(calleeSymbol, session)) return
+        if (isAdvice(calleeSymbol, session)) return
+
+        val containingClassName = calleeSymbol.callableId.classId
+            ?.shortClassName
+            ?.asString()
+        val methodName = calleeSymbol.callableId.callableName.asString()
+
+        val matches = collectMatchingAdvices(session, containingClassName, methodName)
+        if (matches.isEmpty()) return
+        for (advice in matches) {
+            val src = expression.calleeReference.source ?: expression.source ?: continue
+            reporter.reportOn(src, AspectKErrors.WOVEN_CALL_SITE, advice)
+        }
+    }
+
+    @OptIn(SymbolInternals::class, DirectDeclarationsAccess::class)
+    private fun collectMatchingAdvices(
+        session: FirSession,
+        containingClassName: String?,
+        methodName: String,
+    ): List<String> {
+        val aspectSymbols = session.predicateBasedProvider
+            .getSymbolsByPredicate(ASPECT_LOOKUP)
+            .filterIsInstance<FirRegularClassSymbol>()
+
+        val matched = mutableListOf<String>()
+        for (aspect in aspectSymbols) {
+            val aspectShortName = aspect.classId.relativeClassName.asString()
+            for (memberSymbol in aspect.declarationSymbols) {
+                if (memberSymbol !is FirNamedFunctionSymbol) continue
+                val fir = memberSymbol.fir as? FirNamedFunction ?: continue
+                val kindLabel = adviceKindLabel(fir, session) ?: continue
+                val classNamePattern = readPattern(fir, AspectKAnnotations.CLASS_NAME_CLASS_ID, session)
+                val methodNamePattern = readPattern(fir, AspectKAnnotations.METHOD_NAME_CLASS_ID, session)
+                if (!filterMatches(classNamePattern, methodNamePattern, containingClassName, methodName)) continue
+                matched += "$aspectShortName.${fir.name.asString()} ($kindLabel)"
+            }
+        }
+        return matched
+    }
+
+    private fun filterMatches(
+        classNamePattern: String?,
+        methodNamePattern: String?,
+        containingClassName: String?,
+        methodName: String,
+    ): Boolean {
+        classNamePattern?.let { pattern ->
+            val target = containingClassName ?: return false
+            if (!nameGlobMatches(pattern, target)) return false
+        }
+        methodNamePattern?.let { pattern ->
+            if (!nameGlobMatches(pattern, methodName)) return false
+        }
+        return true
+    }
+
+    private fun nameGlobMatches(
+        pattern: String,
+        name: String,
+    ): Boolean {
+        if (pattern == name) return true
+        if (pattern == "*") return true
+        if ('*' !in pattern) return false
+        val regex = pattern
+            .split('*')
+            .joinToString(separator = ".*") { Regex.escape(it) }
+            .let { "^$it$".toRegex() }
+        return regex.matches(name)
+    }
+
+    private fun adviceKindLabel(
+        fn: FirNamedFunction,
+        session: FirSession,
+    ): String? =
+        when {
+            fn.hasAnnotation(AspectKAnnotations.BEFORE_CLASS_ID, session) -> "@Before"
+            fn.hasAnnotation(AspectKAnnotations.AFTER_CLASS_ID, session) -> "@After"
+            fn.hasAnnotation(AspectKAnnotations.AROUND_CLASS_ID, session) -> "@Around"
+            else -> null
+        }
+
+    private fun readPattern(
+        fn: FirNamedFunction,
+        annotationClassId: ClassId,
+        session: FirSession,
+    ): String? =
+        fn
+            .getAnnotationByClassId(annotationClassId, session)
+            ?.getStringArgument(AspectKAnnotations.PATTERN, session)
+
+    private fun isInsideAspectClass(
+        symbol: FirNamedFunctionSymbol,
+        session: FirSession,
+    ): Boolean {
+        val classId = symbol.callableId.classId ?: return false
+        val classSymbol = session.symbolProvider.getClassLikeSymbolByClassId(classId) ?: return false
+        return classSymbol.hasAnnotation(AspectKAnnotations.ASPECT_CLASS_ID, session)
+    }
+
+    private fun isAdvice(
+        symbol: FirNamedFunctionSymbol,
+        session: FirSession,
+    ): Boolean =
+        symbol.hasAnnotation(AspectKAnnotations.BEFORE_CLASS_ID, session) ||
+            symbol.hasAnnotation(AspectKAnnotations.AFTER_CLASS_ID, session) ||
+            symbol.hasAnnotation(AspectKAnnotations.AROUND_CLASS_ID, session)
+}

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/WovenCallSiteChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/WovenCallSiteChecker.kt
@@ -1,6 +1,7 @@
 package com.github.kitakkun.aspectk.compiler.fir.checker
 
 import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import com.github.kitakkun.aspectk.compiler.backend.matching.NamePattern
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.FirSession
@@ -59,8 +60,8 @@ object WovenCallSiteChecker : FirExpressionChecker<FirFunctionCall>(MppCheckerKi
 
         val matches = collectMatchingAdvices(session, containingClassName, methodName)
         if (matches.isEmpty()) return
+        val src = expression.calleeReference.source ?: expression.source ?: return
         for (advice in matches) {
-            val src = expression.calleeReference.source ?: expression.source ?: continue
             reporter.reportOn(src, AspectKErrors.WOVEN_CALL_SITE, advice)
         }
     }
@@ -99,26 +100,12 @@ object WovenCallSiteChecker : FirExpressionChecker<FirFunctionCall>(MppCheckerKi
     ): Boolean {
         classNamePattern?.let { pattern ->
             val target = containingClassName ?: return false
-            if (!nameGlobMatches(pattern, target)) return false
+            if (!NamePattern.matches(pattern, target)) return false
         }
         methodNamePattern?.let { pattern ->
-            if (!nameGlobMatches(pattern, methodName)) return false
+            if (!NamePattern.matches(pattern, methodName)) return false
         }
         return true
-    }
-
-    private fun nameGlobMatches(
-        pattern: String,
-        name: String,
-    ): Boolean {
-        if (pattern == name) return true
-        if (pattern == "*") return true
-        if ('*' !in pattern) return false
-        val regex = pattern
-            .split('*')
-            .joinToString(separator = ".*") { Regex.escape(it) }
-            .let { "^$it$".toRegex() }
-        return regex.matches(name)
     }
 
     private fun adviceKindLabel(


### PR DESCRIPTION
## Summary

Phase 3.5 of the v1 roadmap, stacked on #23 (`feat/v1-phase3.4-matching`).

Adds a FIR-side `WOVEN_CALL_SITE` warning that fires at every function call whose callee is matched by at least one advice declared in the current compilation session. IntelliJ surfaces compiler-plugin diagnostics in the editor automatically, so this gives users an **inline marker telling them which calls are intercepted — without a JetBrains IDE plugin**.

### Implementation

- **Diagnostic** (`AspectKErrors.WOVEN_CALL_SITE`) — `warning1<KtElement, String>`. The string argument names the advising function, e.g. `"GreetingTracer.aroundGreet (@Around)"`. `warning` is the weakest severity the public diagnostic factory exposes in 2.3.21; if a true `info`-level factory becomes available we can swap.
- **Checker** (`WovenCallSiteChecker`) — `FirExpressionChecker<FirFunctionCall>` registered on the `AspectKFirCheckerExtension`'s `expressionCheckers`.
- **Aspect discovery uses the FIR predicate system**. The extension registers `LookupPredicate.annotated(@Aspect)` in `registerPredicates`, so the session-wide annotation index includes `@Aspect`. The checker queries `session.predicateBasedProvider.getSymbolsByPredicate(ASPECT_LOOKUP)` to enumerate aspects in O(1) per hit instead of walking the module manually.
- For each `@Aspect`, advice members are filtered by `` `@Before` `` / `` `@After` `` / `` `@Around` `` annotation. The advice's `` `@ClassName` `` / `` `@MethodName` `` patterns are read off the FIR annotations and matched against the callee with a simple glob (`*`-only).
- Calls into `@Aspect` classes themselves and calls to advice functions are skipped — IR never weaves those either.

### Trade-off

**Over-approximation.** Only `` `@ClassName` `` / `` `@MethodName` `` are honoured at FIR. The remaining matching dimensions (`` `@Package` `` / `` `@Visibility` `` / `` `@Modality` `` / `` `@Modifiers` `` / `` `@Annotated` ``) are not yet mirrored. IR remains the authoritative weaver, so the FIR diagnostic may occasionally fire on a call that IR's stricter matching rejects. Acceptable for an editor marker — follow-ups can tighten parity.

### Verified

Building `test/` with the existing `GreetingTracer` (`@Around`-advised `Greeter.greet`) now emits:

```
w: file://…/test/Main.kt:8:23 intercepted by GreetingTracer.aroundGreet (@Around)
```

exactly at the `greet("world")` invocation in `main`.

## Test plan

- [x] `./gradlew build` — green.
- [x] Confirmed the warning fires on the test sample's `greet("world")` call with the expected message.
- [ ] (Deferred to Phase 7) compiler-test-framework cases that cover (a) non-matching calls don't fire, (b) advice-to-advice calls are skipped, (c) cross-aspect matches show one diagnostic per matching advice.