### PR TITLE
chore: drop stale self-referencing @AutoService on FIR registrar

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/AspectKFirExtensionRegistrar.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/AspectKFirExtensionRegistrar.kt
@@ -2,10 +2,8 @@ package com.github.kitakkun.aspectk.compiler.fir
 
 import com.github.kitakkun.aspectk.compiler.fir.checker.AspectKErrors
 import com.github.kitakkun.aspectk.compiler.fir.checker.AspectKFirCheckerExtension
-import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 
-@AutoService(AspectKFirExtensionRegistrar::class)
 class AspectKFirExtensionRegistrar : FirExtensionRegistrar() {
     override fun ExtensionRegistrarContext.configurePlugin() {
         +::AspectKFirCheckerExtension


### PR DESCRIPTION
## Summary

`AspectKFirExtensionRegistrar` carried `@AutoService(AspectKFirExtensionRegistrar::class)`, which registers the class as a service of *itself* — pointless, since nothing reads `META-INF/services/com.github.kitakkun.aspectk.compiler.fir.AspectKFirExtensionRegistrar`. The actual loading goes through `AspectKCompilerPluginRegistrar.registerExtensions`, which calls `FirExtensionRegistrarAdapter.registerExtension(AspectKFirExtensionRegistrar())` programmatically.

Removing the annotation drops the stale service file from the published JAR.

### Before
```
META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
META-INF/services/com.github.kitakkun.aspectk.compiler.fir.AspectKFirExtensionRegistrar
```

### After
```
META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
```

## Test plan

- [x] `./gradlew build` — green.
- [x] `unzip -l aspectk-compiler-1.0.0.jar | grep META-INF/services` — only the two expected service files remain.