### PR TITLE
Phase 3.5.5: reinstate K2 compiler test framework with box & diagnostic runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 build/
 .idea/*
 !.idea/codeStyles
+.kotlin/
 
 .DS_Store

--- a/aspectk-compiler/build.gradle.kts
+++ b/aspectk-compiler/build.gradle.kts
@@ -76,14 +76,22 @@ tasks.test {
     setLibraryProperty("org.jetbrains.kotlin.test.kotlin-script-runtime", "kotlin-script-runtime")
     setLibraryProperty("org.jetbrains.kotlin.test.kotlin-annotations-jvm", "kotlin-annotations-jvm")
 
+    // Filter to the main jar only — exclude `-sources`/`-javadoc` jars that
+    // a future maven-publish configuration might add.
     val annotationsJar = rootProject.layout.projectDirectory
         .dir("aspectk-annotations/build/libs")
         .asFileTree
-        .matching { include("aspectk-annotations-jvm-*.jar") }
+        .matching {
+            include("aspectk-annotations-jvm-*.jar")
+            exclude("aspectk-annotations-jvm-*-sources.jar", "aspectk-annotations-jvm-*-javadoc.jar")
+        }
     val coreJar = rootProject.layout.projectDirectory
         .dir("aspectk-core/build/libs")
         .asFileTree
-        .matching { include("aspectk-core-jvm-*.jar") }
+        .matching {
+            include("aspectk-core-jvm-*.jar")
+            exclude("aspectk-core-jvm-*-sources.jar", "aspectk-core-jvm-*-javadoc.jar")
+        }
     doFirst {
         systemProperty("aspectk.annotations.jar", annotationsJar.singleFile.absolutePath)
         systemProperty("aspectk.core.jar", coreJar.singleFile.absolutePath)

--- a/aspectk-compiler/build.gradle.kts
+++ b/aspectk-compiler/build.gradle.kts
@@ -4,8 +4,11 @@ plugins {
     alias(libs.plugins.aspectkCommon)
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.ksp)
+    `java-test-fixtures`
     `maven-publish`
 }
+
+val testArtifacts: Configuration by configurations.creating
 
 dependencies {
     implementation(project(":aspectk-plugin-common"))
@@ -13,12 +16,94 @@ dependencies {
     compileOnly(libs.kotlin.compiler)
     compileOnly(libs.auto.service)
     ksp(libs.auto.service.ksp)
+
+    testFixturesApi(libs.kotlin.test.junit5)
+    testFixturesApi(libs.kotlin.compiler.internal.test.framework)
+    testFixturesApi(libs.kotlin.compiler)
+    testFixturesRuntimeOnly(libs.junit4)
+
+    // Resolved into test-runtime system properties so the test framework can locate
+    // stdlib / reflect / test jars by absolute path at startup.
+    testArtifacts(libs.kotlin.stdlib)
+    testArtifacts(libs.kotlin.stdlib.jdk8)
+    testArtifacts(libs.kotlin.reflect)
+    testArtifacts(libs.kotlin.test)
+    testArtifacts(libs.kotlin.script.runtime)
+    testArtifacts(libs.kotlin.annotations.jvm)
+}
+
+sourceSets {
+    test {
+        java.setSrcDirs(listOf("test", "test-gen"))
+        resources.setSrcDirs(listOf("testData"))
+    }
+    testFixtures {
+        java.setSrcDirs(listOf("test-fixtures"))
+    }
 }
 
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions.freeCompilerArgs.add("-Xcontext-parameters")
     compilerOptions.optIn.add("org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI")
 }
+
+fun Test.setLibraryProperty(
+    propName: String,
+    jarName: String,
+) {
+    val path = testArtifacts.files
+        .find { """$jarName-\d.*""".toRegex().matches(it.name) }
+        ?.absolutePath
+        ?: error("testArtifacts is missing $jarName — add the matching `testArtifacts(\"<group>:$jarName:<version>\")` coordinate")
+    systemProperty(propName, path)
+}
+
+tasks.test {
+    dependsOn(testArtifacts)
+    dependsOn(":aspectk-annotations:jvmJar")
+    dependsOn(":aspectk-core:jvmJar")
+
+    useJUnitPlatform()
+    workingDir = rootDir
+
+    systemProperty("idea.home.path", rootDir)
+    systemProperty("idea.ignore.disabled.plugins", "true")
+
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-stdlib", "kotlin-stdlib")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-stdlib-jdk8", "kotlin-stdlib-jdk8")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-reflect", "kotlin-reflect")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-test", "kotlin-test")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-script-runtime", "kotlin-script-runtime")
+    setLibraryProperty("org.jetbrains.kotlin.test.kotlin-annotations-jvm", "kotlin-annotations-jvm")
+
+    val annotationsJar = rootProject.layout.projectDirectory
+        .dir("aspectk-annotations/build/libs")
+        .asFileTree
+        .matching { include("aspectk-annotations-jvm-*.jar") }
+    val coreJar = rootProject.layout.projectDirectory
+        .dir("aspectk-core/build/libs")
+        .asFileTree
+        .matching { include("aspectk-core-jvm-*.jar") }
+    doFirst {
+        systemProperty("aspectk.annotations.jar", annotationsJar.singleFile.absolutePath)
+        systemProperty("aspectk.core.jar", coreJar.singleFile.absolutePath)
+    }
+}
+
+val generateTests by tasks.registering(JavaExec::class) {
+    inputs.dir(layout.projectDirectory.dir("testData"))
+    outputs.dir(layout.projectDirectory.dir("test-gen"))
+    classpath = sourceSets.testFixtures.get().runtimeClasspath
+    mainClass.set("com.github.kitakkun.aspectk.compiler.test.GenerateTestsKt")
+    workingDir = rootDir
+}
+tasks.compileTestKotlin { dependsOn(generateTests) }
+tasks
+    .matching {
+        it.name == "kspTestKotlin" || it.name == "compileTestJava"
+    }.configureEach {
+        dependsOn(generateTests)
+    }
 
 publishing {
     publications {

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/GenerateTests.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/GenerateTests.kt
@@ -1,0 +1,18 @@
+package com.github.kitakkun.aspectk.compiler.test
+
+import com.github.kitakkun.aspectk.compiler.test.runners.AbstractAspectKBoxTest
+import com.github.kitakkun.aspectk.compiler.test.runners.AbstractAspectKDiagnosticTest
+import org.jetbrains.kotlin.generators.dsl.junit5.generateTestGroupSuiteWithJUnit5
+
+fun main() {
+    generateTestGroupSuiteWithJUnit5 {
+        testGroup(testDataRoot = "aspectk-compiler/testData", testsRoot = "aspectk-compiler/test-gen") {
+            testClass<AbstractAspectKDiagnosticTest> {
+                model("diagnostics")
+            }
+            testClass<AbstractAspectKBoxTest> {
+                model("box")
+            }
+        }
+    }
+}

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/runners/AbstractAspectKBoxTest.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/runners/AbstractAspectKBoxTest.kt
@@ -1,0 +1,29 @@
+package com.github.kitakkun.aspectk.compiler.test.runners
+
+import com.github.kitakkun.aspectk.compiler.test.services.AspectKClasspathConfigurator
+import com.github.kitakkun.aspectk.compiler.test.services.AspectKRuntimeClasspathProvider
+import com.github.kitakkun.aspectk.compiler.test.services.ExtensionRegistrarConfigurator
+import org.jetbrains.kotlin.test.FirParser
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
+import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives
+import org.jetbrains.kotlin.test.runners.codegen.AbstractFirBlackBoxCodegenTestBase
+import org.jetbrains.kotlin.test.services.EnvironmentBasedStandardLibrariesPathProvider
+import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
+
+open class AbstractAspectKBoxTest : AbstractFirBlackBoxCodegenTestBase(FirParser.LightTree) {
+    override fun createKotlinStandardLibrariesPathProvider(): KotlinStandardLibrariesPathProvider = EnvironmentBasedStandardLibrariesPathProvider
+
+    override fun configure(builder: TestConfigurationBuilder) {
+        super.configure(builder)
+        with(builder) {
+            defaultDirectives {
+                +CodegenTestDirectives.DUMP_IR
+                +CodegenTestDirectives.IGNORE_DEXING
+                +JvmEnvironmentConfigurationDirectives.FULL_JDK
+            }
+            useConfigurators(::ExtensionRegistrarConfigurator, ::AspectKClasspathConfigurator)
+            useCustomRuntimeClasspathProviders(::AspectKRuntimeClasspathProvider)
+        }
+    }
+}

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/runners/AbstractAspectKDiagnosticTest.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/runners/AbstractAspectKDiagnosticTest.kt
@@ -1,0 +1,28 @@
+package com.github.kitakkun.aspectk.compiler.test.runners
+
+import com.github.kitakkun.aspectk.compiler.test.services.AspectKClasspathConfigurator
+import com.github.kitakkun.aspectk.compiler.test.services.AspectKRuntimeClasspathProvider
+import com.github.kitakkun.aspectk.compiler.test.services.ExtensionRegistrarConfigurator
+import org.jetbrains.kotlin.test.FirParser
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.FirDiagnosticsDirectives
+import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives
+import org.jetbrains.kotlin.test.runners.AbstractFirDiagnosticTestBase
+import org.jetbrains.kotlin.test.services.EnvironmentBasedStandardLibrariesPathProvider
+import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
+
+open class AbstractAspectKDiagnosticTest : AbstractFirDiagnosticTestBase(FirParser.LightTree) {
+    override fun createKotlinStandardLibrariesPathProvider(): KotlinStandardLibrariesPathProvider = EnvironmentBasedStandardLibrariesPathProvider
+
+    override fun configure(builder: TestConfigurationBuilder) {
+        super.configure(builder)
+        with(builder) {
+            defaultDirectives {
+                +FirDiagnosticsDirectives.FIR_DUMP
+                +JvmEnvironmentConfigurationDirectives.FULL_JDK
+            }
+            useConfigurators(::ExtensionRegistrarConfigurator, ::AspectKClasspathConfigurator)
+            useCustomRuntimeClasspathProviders(::AspectKRuntimeClasspathProvider)
+        }
+    }
+}

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/AspectKClasspathConfigurator.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/AspectKClasspathConfigurator.kt
@@ -1,0 +1,24 @@
+package com.github.kitakkun.aspectk.compiler.test.services
+
+import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoot
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.EnvironmentConfigurator
+import org.jetbrains.kotlin.test.services.TestServices
+import java.io.File
+
+class AspectKClasspathConfigurator(
+    testServices: TestServices,
+) : EnvironmentConfigurator(testServices) {
+    override fun configureCompilerConfiguration(
+        configuration: CompilerConfiguration,
+        module: TestModule,
+    ) {
+        val annotations = System.getProperty("aspectk.annotations.jar")
+            ?: error("System property `aspectk.annotations.jar` is not set")
+        val core = System.getProperty("aspectk.core.jar")
+            ?: error("System property `aspectk.core.jar` is not set")
+        configuration.addJvmClasspathRoot(File(annotations))
+        configuration.addJvmClasspathRoot(File(core))
+    }
+}

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/AspectKRuntimeClasspathProvider.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/AspectKRuntimeClasspathProvider.kt
@@ -1,0 +1,18 @@
+package com.github.kitakkun.aspectk.compiler.test.services
+
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.RuntimeClasspathProvider
+import org.jetbrains.kotlin.test.services.TestServices
+import java.io.File
+
+class AspectKRuntimeClasspathProvider(
+    testServices: TestServices,
+) : RuntimeClasspathProvider(testServices) {
+    override fun runtimeClassPaths(module: TestModule): List<File> {
+        val annotations = System.getProperty("aspectk.annotations.jar")
+            ?: error("System property `aspectk.annotations.jar` is not set")
+        val core = System.getProperty("aspectk.core.jar")
+            ?: error("System property `aspectk.core.jar` is not set")
+        return listOf(File(annotations), File(core))
+    }
+}

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/ExtensionRegistrarConfigurator.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/ExtensionRegistrarConfigurator.kt
@@ -1,0 +1,25 @@
+package com.github.kitakkun.aspectk.compiler.test.services
+
+import com.github.kitakkun.aspectk.compiler.backend.AspectKIrGenerationExtension
+import com.github.kitakkun.aspectk.compiler.fir.AspectKFirExtensionRegistrar
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.EnvironmentConfigurator
+import org.jetbrains.kotlin.test.services.TestServices
+
+@OptIn(ExperimentalCompilerApi::class)
+class ExtensionRegistrarConfigurator(
+    testServices: TestServices,
+) : EnvironmentConfigurator(testServices) {
+    override fun CompilerPluginRegistrar.ExtensionStorage.registerCompilerExtensions(
+        module: TestModule,
+        configuration: CompilerConfiguration,
+    ) {
+        FirExtensionRegistrarAdapter.registerExtension(AspectKFirExtensionRegistrar())
+        IrGenerationExtension.registerExtension(AspectKIrGenerationExtension())
+    }
+}

--- a/aspectk-compiler/testData/box/beforeAdvice.fir.ir.txt
+++ b/aspectk-compiler/testData/box/beforeAdvice.fir.ir.txt
@@ -1,0 +1,107 @@
+FILE fqName:<root> fileName:/BeforeAdvice.kt
+  PROPERTY name:trace visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:trace type:kotlin.String visibility:private [static]
+      EXPRESSION_BODY
+        CONST String type=kotlin.String value=""
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-trace> visibility:public modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:trace visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-trace> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:trace type:kotlin.String visibility:private [static]' type=kotlin.String origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-trace> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.String
+      correspondingProperty: PROPERTY name:trace visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:trace type:kotlin.String visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.String declared in <root>.<set-trace>' type=kotlin.String origin=null
+  CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Greeter
+    CONSTRUCTOR visibility:public returnType:<root>.Greeter [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:greet visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Greeter
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+      BLOCK_BODY
+        CALL 'public final fun beforeGreet (): kotlin.Unit declared in <root>.GreetingTracer' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.GreetingTracer' type=<root>.GreetingTracer origin=null
+        RETURN type=kotlin.Nothing from='public final fun greet (name: kotlin.String): kotlin.String declared in <root>.Greeter'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="hello "
+            GET_VAR 'name: kotlin.String declared in <root>.Greeter.greet' type=kotlin.String origin=null
+  CLASS CLASS name:GreetingTracer modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.GreetingTracer
+    CONSTRUCTOR visibility:public returnType:<root>.GreetingTracer [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:GreetingTracer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeGreet visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.GreetingTracer
+      annotations:
+        Before
+        ClassName(pattern = "Greeter")
+        MethodName(pattern = "greet")
+      BLOCK_BODY
+        CALL 'public final fun <set-trace> (<set-?>: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.Unit origin=PLUSEQ
+          ARG <set-?>: CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=PLUSEQ
+            ARG <this>: CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=PLUSEQ
+            ARG other: CONST String type=kotlin.String value="[before]"
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:result type:kotlin.String [val]
+        CALL 'public final fun greet (name: kotlin.String): kotlin.String declared in <root>.Greeter' type=kotlin.String origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Greeter' type=<root>.Greeter origin=null
+          ARG name: CONST String type=kotlin.String value="world"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: GET_VAR 'val result: kotlin.String declared in <root>.box' type=kotlin.String origin=null
+              ARG arg1: CONST String type=kotlin.String value="hello world"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: greet returned '"
+              GET_VAR 'val result: kotlin.String declared in <root>.box' type=kotlin.String origin=null
+              CONST String type=kotlin.String value="'"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              ARG arg1: CONST String type=kotlin.String value="[before]"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: trace was '"
+              CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              CONST String type=kotlin.String value="'"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/beforeAdvice.kt
+++ b/aspectk-compiler/testData/box/beforeAdvice.kt
@@ -1,0 +1,29 @@
+// FILE: BeforeAdvice.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.MethodName
+
+var trace: String = ""
+
+class Greeter {
+    fun greet(name: String): String = "hello $name"
+}
+
+@Aspect
+class GreetingTracer {
+    @Before
+    @ClassName("Greeter")
+    @MethodName("greet")
+    fun beforeGreet() {
+        trace += "[before]"
+    }
+}
+
+fun box(): String {
+    val result = Greeter().greet("world")
+    if (result != "hello world") return "FAIL: greet returned '$result'"
+    if (trace != "[before]") return "FAIL: trace was '$trace'"
+    return "OK"
+}

--- a/aspectk-compiler/testData/diagnostics/adviceOutsideAspect.fir.txt
+++ b/aspectk-compiler/testData/diagnostics/adviceOutsideAspect.fir.txt
@@ -1,0 +1,10 @@
+FILE: AdviceOutsideAspect.kt
+    public final class NotAnAspect : R|kotlin/Any| {
+        public constructor(): R|NotAnAspect| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|() @R|com/github/kitakkun/aspectk/annotations/MethodName|(pattern = String(foo)) public final fun beforeFoo(): R|kotlin/Unit| {
+        }
+
+    }

--- a/aspectk-compiler/testData/diagnostics/adviceOutsideAspect.kt
+++ b/aspectk-compiler/testData/diagnostics/adviceOutsideAspect.kt
@@ -1,0 +1,10 @@
+// FILE: AdviceOutsideAspect.kt
+
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.MethodName
+
+class NotAnAspect {
+    <!ADVICE_OUTSIDE_ASPECT_CLASS!>@Before
+    @MethodName("foo")
+    fun beforeFoo() {}<!>
+}


### PR DESCRIPTION
## Summary

Phase 3.5.5 of the v1 roadmap, stacked on #24 (`feat/v1-phase3.5-fir-matching`).

Brings back the official `kotlin-compiler-internal-test-framework` harness that PR #13 introduced and Phase 0 rolled back. Adapted to Kotlin 2.3.21 and tied into the v1 checker / IR-transformer surface.

### Adaptations from PR #13 (1.9.22 → 2.3.21)

- `generateTestGroupSuiteWithJUnit5` moved package from `org.jetbrains.kotlin.generators` to `org.jetbrains.kotlin.generators.dsl.junit5`.
- `AspectKStandardLibrariesPathProvider` dropped — the framework's `EnvironmentBasedStandardLibrariesPathProvider` already does what we need on 2.3.21.
- The `NioFiles` shim from PR #13 is dropped (the matching overload added in 1.9.22's test framework is now built into 2.3.21's compiler).
- `ExtensionRegistrarConfigurator` constructs `AspectKIrGenerationExtension()` without arguments — the v1 rewrite dropped the `messageCollector` parameter.

### Module layout (`aspectk-compiler/`)

- `test-fixtures/` — runner & service classes
  - `runners/AbstractAspectKDiagnosticTest` — extends `AbstractFirDiagnosticTestBase(FirParser.LightTree)`.
  - `runners/AbstractAspectKBoxTest` — extends `AbstractFirBlackBoxCodegenTestBase(FirParser.LightTree)` with `CodegenTestDirectives.IGNORE_DEXING` so box tests don't need R8 on the classpath.
  - `services/ExtensionRegistrarConfigurator` — registers both the FIR registrar and the IR generation extension in the test compiler.
  - `services/AspectKClasspathConfigurator` — adds `aspectk-annotations` and `aspectk-core` to the compile classpath so test data can `import com.github.kitakkun.aspectk.*`.
  - `services/AspectKRuntimeClasspathProvider` — same jars on the box-test runtime classpath.
  - `GenerateTests.kt` — walks `testData/` and emits one JUnit 5 test class per abstract runner under `test-gen/`.
- `testData/diagnostics/adviceOutsideAspect.kt` — verifies `AdviceScopeChecker` fires `ADVICE_OUTSIDE_ASPECT_CLASS` when `` `@Before` `` lives outside an `` `@Aspect` `` class.
- `testData/box/beforeAdvice.kt` — verifies `` `@Before` `` weaves into `Greeter.greet` and the side effect (`trace = "[before]"`) is observed before the original body's return value flows back.
- Golden files (`.fir.txt` / `.fir.ir.txt`) committed alongside each `.kt`.

### Gradle wiring

- `java-test-fixtures` plugin + `testArtifacts` configuration collecting stdlib / reflect / kotlin-test / kotlin-script-runtime / kotlin-annotations-jvm jars by absolute path. Exposed to the test task as `org.jetbrains.kotlin.test.<jar>` system properties so the framework can find them at startup.
- `tasks.test` depends on `aspectk-annotations:jvmJar` / `aspectk-core:jvmJar` and passes their resolved paths as `aspectk.annotations.jar` / `aspectk.core.jar` system properties that the two configurators read at runtime.
- `generateTests` JavaExec task regenerates `test-gen/` from `testData/` and hooks before `compileTestKotlin` and `kspTestKotlin`/`compileTestJava`.

### Follow-up coverage (not in this PR)

- More diagnostic cases — `BindingAnnotationChecker`, `PointcutAnnotationChecker`, `WovenCallSiteChecker`.
- More box cases — `` `@After` ``, `` `@Around` ``+`proceed`, `replace*` overrides, binding extraction.
- The 1.9.22-era v0.x golden files (now historical) aren't carried forward — v1's testData is a fresh start.

## Test plan

- [x] `./gradlew :aspectk-compiler:test` — green (4 tests, both fixtures + the framework's "all files present" gates).
- [x] `./gradlew build` — green.
- [x] Removing the diagnostic from `AdviceScopeChecker` makes the diagnostic test fail — confirmed the harness actually exercises the checker rather than just running through it.