### PR TITLE
Phase 3.5.6: expand testData coverage for v1 checkers and IR weaving

### DIFF
--- a/aspectk-compiler/testData/box/afterAdvice.fir.ir.txt
+++ b/aspectk-compiler/testData/box/afterAdvice.fir.ir.txt
@@ -1,0 +1,113 @@
+FILE fqName:<root> fileName:/AfterAdvice.kt
+  PROPERTY name:trace visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:trace type:kotlin.String visibility:private [static]
+      EXPRESSION_BODY
+        CONST String type=kotlin.String value=""
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-trace> visibility:public modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:trace visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-trace> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:trace type:kotlin.String visibility:private [static]' type=kotlin.String origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-trace> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.String
+      correspondingProperty: PROPERTY name:trace visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:trace type:kotlin.String visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.String declared in <root>.<set-trace>' type=kotlin.String origin=null
+  CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Greeter
+    CONSTRUCTOR visibility:public returnType:<root>.Greeter [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:greet visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Greeter
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+      BLOCK_BODY
+        TRY type=kotlin.String
+          try: BLOCK type=kotlin.String origin=null
+            CALL 'public final fun <set-trace> (<set-?>: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.Unit origin=PLUSEQ
+              ARG <set-?>: CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=PLUSEQ
+                ARG <this>: CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=PLUSEQ
+                ARG other: CONST String type=kotlin.String value="[body]"
+            RETURN type=kotlin.Nothing from='public final fun greet (name: kotlin.String): kotlin.String declared in <root>.Greeter'
+              STRING_CONCATENATION type=kotlin.String
+                CONST String type=kotlin.String value="hello "
+                GET_VAR 'name: kotlin.String declared in <root>.Greeter.greet' type=kotlin.String origin=null
+          finally: CALL 'public final fun afterGreet (): kotlin.Unit declared in <root>.GreetingTracer' type=kotlin.Unit origin=null
+            ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.GreetingTracer' type=<root>.GreetingTracer origin=null
+  CLASS CLASS name:GreetingTracer modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.GreetingTracer
+    CONSTRUCTOR visibility:public returnType:<root>.GreetingTracer [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:GreetingTracer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:afterGreet visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.GreetingTracer
+      annotations:
+        After
+        ClassName(pattern = "Greeter")
+        MethodName(pattern = "greet")
+      BLOCK_BODY
+        CALL 'public final fun <set-trace> (<set-?>: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.Unit origin=PLUSEQ
+          ARG <set-?>: CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=PLUSEQ
+            ARG <this>: CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=PLUSEQ
+            ARG other: CONST String type=kotlin.String value="[after]"
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:result type:kotlin.String [val]
+        CALL 'public final fun greet (name: kotlin.String): kotlin.String declared in <root>.Greeter' type=kotlin.String origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Greeter' type=<root>.Greeter origin=null
+          ARG name: CONST String type=kotlin.String value="world"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: GET_VAR 'val result: kotlin.String declared in <root>.box' type=kotlin.String origin=null
+              ARG arg1: CONST String type=kotlin.String value="hello world"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: greet returned '"
+              GET_VAR 'val result: kotlin.String declared in <root>.box' type=kotlin.String origin=null
+              CONST String type=kotlin.String value="'"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              ARG arg1: CONST String type=kotlin.String value="[body][after]"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: trace was '"
+              CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              CONST String type=kotlin.String value="'"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/afterAdvice.kt
+++ b/aspectk-compiler/testData/box/afterAdvice.kt
@@ -1,0 +1,32 @@
+// FILE: AfterAdvice.kt
+
+import com.github.kitakkun.aspectk.annotations.After
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.MethodName
+
+var trace: String = ""
+
+class Greeter {
+    fun greet(name: String): String {
+        trace += "[body]"
+        return "hello $name"
+    }
+}
+
+@Aspect
+class GreetingTracer {
+    @After
+    @ClassName("Greeter")
+    @MethodName("greet")
+    fun afterGreet() {
+        trace += "[after]"
+    }
+}
+
+fun box(): String {
+    val result = Greeter().greet("world")
+    if (result != "hello world") return "FAIL: greet returned '$result'"
+    if (trace != "[body][after]") return "FAIL: trace was '$trace'"
+    return "OK"
+}

--- a/aspectk-compiler/testData/box/aroundAdviceProceed.fir.ir.txt
+++ b/aspectk-compiler/testData/box/aroundAdviceProceed.fir.ir.txt
@@ -1,0 +1,137 @@
+FILE fqName:<root> fileName:/AroundAdviceProceed.kt
+  PROPERTY name:trace visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:trace type:kotlin.String visibility:private [static]
+      EXPRESSION_BODY
+        CONST String type=kotlin.String value=""
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-trace> visibility:public modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:trace visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-trace> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:trace type:kotlin.String visibility:private [static]' type=kotlin.String origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-trace> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.String
+      correspondingProperty: PROPERTY name:trace visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:trace type:kotlin.String visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.String declared in <root>.<set-trace>' type=kotlin.String origin=null
+  CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Greeter
+    CONSTRUCTOR visibility:public returnType:<root>.Greeter [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:greet visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Greeter
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+      BLOCK_BODY
+        CALL 'public final fun <set-trace> (<set-?>: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.Unit origin=PLUSEQ
+          ARG <set-?>: CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=PLUSEQ
+            ARG <this>: CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=PLUSEQ
+            ARG other: CONST String type=kotlin.String value="[before]"
+        VAR name:r type:kotlin.String [val]
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="hello "
+            GET_VAR 'name: kotlin.String declared in <root>.Greeter.greet' type=kotlin.String origin=null
+        CALL 'public final fun <set-trace> (<set-?>: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.Unit origin=PLUSEQ
+          ARG <set-?>: CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=PLUSEQ
+            ARG <this>: CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=PLUSEQ
+            ARG other: STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="[after:"
+              GET_VAR 'val r: kotlin.String declared in <root>.Greeter.greet' type=kotlin.String origin=null
+              CONST String type=kotlin.String value="]"
+        RETURN type=kotlin.Nothing from='public final fun greet (name: kotlin.String): kotlin.String declared in <root>.Greeter'
+          GET_VAR 'val r: kotlin.String declared in <root>.Greeter.greet' type=kotlin.String origin=null
+  CLASS CLASS name:GreetingTracer modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.GreetingTracer
+    CONSTRUCTOR visibility:public returnType:<root>.GreetingTracer [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:GreetingTracer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:aroundGreet visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.GreetingTracer
+      annotations:
+        Around
+        ClassName(pattern = "Greeter")
+        MethodName(pattern = "greet")
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun aroundGreet (): kotlin.String declared in <root>.GreetingTracer'
+          CALL 'public final fun interceptableAdvice <R> (block: @[ExtensionFunctionType] kotlin.Function1<com.github.kitakkun.aspectk.core.AroundScope<R of com.github.kitakkun.aspectk.core.interceptableAdvice>, R of com.github.kitakkun.aspectk.core.interceptableAdvice>): R of com.github.kitakkun.aspectk.core.interceptableAdvice declared in com.github.kitakkun.aspectk.core' type=kotlin.String origin=null
+            TYPE_ARG R: kotlin.String
+            ARG block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<com.github.kitakkun.aspectk.core.AroundScope<kotlin.String>, kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.String
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$interceptableAdvice index:0 type:com.github.kitakkun.aspectk.core.AroundScope<kotlin.String>
+                BLOCK_BODY
+                  CALL 'public final fun <set-trace> (<set-?>: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.Unit origin=PLUSEQ
+                    ARG <set-?>: CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=PLUSEQ
+                      ARG <this>: CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=PLUSEQ
+                      ARG other: CONST String type=kotlin.String value="[before]"
+                  VAR name:r type:kotlin.String [val]
+                    CALL 'public final fun proceed (): R of com.github.kitakkun.aspectk.core.AroundScope declared in com.github.kitakkun.aspectk.core.AroundScope' type=kotlin.String origin=null
+                      ARG <this>: GET_VAR '$this$interceptableAdvice: com.github.kitakkun.aspectk.core.AroundScope<kotlin.String> declared in <root>.GreetingTracer.aroundGreet.<anonymous>' type=com.github.kitakkun.aspectk.core.AroundScope<kotlin.String> origin=IMPLICIT_ARGUMENT
+                  CALL 'public final fun <set-trace> (<set-?>: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.Unit origin=PLUSEQ
+                    ARG <set-?>: CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=PLUSEQ
+                      ARG <this>: CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=PLUSEQ
+                      ARG other: STRING_CONCATENATION type=kotlin.String
+                        CONST String type=kotlin.String value="[after:"
+                        GET_VAR 'val r: kotlin.String declared in <root>.GreetingTracer.aroundGreet.<anonymous>' type=kotlin.String origin=null
+                        CONST String type=kotlin.String value="]"
+                  RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$interceptableAdvice: com.github.kitakkun.aspectk.core.AroundScope<kotlin.String>): kotlin.String declared in <root>.GreetingTracer.aroundGreet'
+                    GET_VAR 'val r: kotlin.String declared in <root>.GreetingTracer.aroundGreet.<anonymous>' type=kotlin.String origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:result type:kotlin.String [val]
+        CALL 'public final fun greet (name: kotlin.String): kotlin.String declared in <root>.Greeter' type=kotlin.String origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Greeter' type=<root>.Greeter origin=null
+          ARG name: CONST String type=kotlin.String value="world"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: GET_VAR 'val result: kotlin.String declared in <root>.box' type=kotlin.String origin=null
+              ARG arg1: CONST String type=kotlin.String value="hello world"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: greet returned '"
+              GET_VAR 'val result: kotlin.String declared in <root>.box' type=kotlin.String origin=null
+              CONST String type=kotlin.String value="'"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              ARG arg1: CONST String type=kotlin.String value="[before][after:hello world]"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: trace was '"
+              CALL 'public final fun <get-trace> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              CONST String type=kotlin.String value="'"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/aroundAdviceProceed.kt
+++ b/aspectk-compiler/testData/box/aroundAdviceProceed.kt
@@ -1,0 +1,33 @@
+// FILE: AroundAdviceProceed.kt
+
+import com.github.kitakkun.aspectk.annotations.Around
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.core.interceptableAdvice
+
+var trace: String = ""
+
+class Greeter {
+    fun greet(name: String): String = "hello $name"
+}
+
+@Aspect
+class GreetingTracer {
+    @Around
+    @ClassName("Greeter")
+    @MethodName("greet")
+    fun aroundGreet(): String = interceptableAdvice {
+        trace += "[before]"
+        val r = proceed()
+        trace += "[after:$r]"
+        r
+    }
+}
+
+fun box(): String {
+    val result = Greeter().greet("world")
+    if (result != "hello world") return "FAIL: greet returned '$result'"
+    if (trace != "[before][after:hello world]") return "FAIL: trace was '$trace'"
+    return "OK"
+}

--- a/aspectk-compiler/testData/box/aroundReplaceValueParameter.fir.ir.txt
+++ b/aspectk-compiler/testData/box/aroundReplaceValueParameter.fir.ir.txt
@@ -1,0 +1,98 @@
+FILE fqName:<root> fileName:/AroundReplaceValueParameter.kt
+  CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Greeter
+    CONSTRUCTOR visibility:public returnType:<root>.Greeter [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:greet visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Greeter
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+      BLOCK_BODY
+        VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.String [var]
+          GET_VAR 'name: kotlin.String declared in <root>.Greeter.greet' type=kotlin.String origin=null
+        SET_VAR 'var tmp_0: kotlin.String declared in <root>.Greeter.greet' type=kotlin.Unit origin=EQ
+          CALL 'public final fun uppercase (<this>: kotlin.String): kotlin.String declared in kotlin.text' type=kotlin.String origin=null
+            ARG <this>: GET_VAR 'var tmp_0: kotlin.String declared in <root>.Greeter.greet' type=kotlin.String origin=null
+        RETURN type=kotlin.Nothing from='public final fun greet (name: kotlin.String): kotlin.String declared in <root>.Greeter'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="hello "
+            GET_VAR 'var tmp_0: kotlin.String declared in <root>.Greeter.greet' type=kotlin.String origin=null
+  CLASS CLASS name:Uppercaser modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Uppercaser
+    CONSTRUCTOR visibility:public returnType:<root>.Uppercaser [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Uppercaser modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:aroundGreet visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Uppercaser
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+        annotations:
+          ValueParameter(index = 0, name = <null>)
+      annotations:
+        Around
+        ClassName(pattern = "Greeter")
+        MethodName(pattern = "greet")
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun aroundGreet (name: kotlin.String): kotlin.String declared in <root>.Uppercaser'
+          CALL 'public final fun interceptableAdvice <R> (block: @[ExtensionFunctionType] kotlin.Function1<com.github.kitakkun.aspectk.core.AroundScope<R of com.github.kitakkun.aspectk.core.interceptableAdvice>, R of com.github.kitakkun.aspectk.core.interceptableAdvice>): R of com.github.kitakkun.aspectk.core.interceptableAdvice declared in com.github.kitakkun.aspectk.core' type=kotlin.String origin=null
+            TYPE_ARG R: kotlin.String
+            ARG block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<com.github.kitakkun.aspectk.core.AroundScope<kotlin.String>, kotlin.String> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.String
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$interceptableAdvice index:0 type:com.github.kitakkun.aspectk.core.AroundScope<kotlin.String>
+                BLOCK_BODY
+                  CALL 'public final fun replaceValueParameter (index: kotlin.Int, value: kotlin.Any?): kotlin.Unit declared in com.github.kitakkun.aspectk.core.AroundScope' type=kotlin.Unit origin=null
+                    ARG <this>: GET_VAR '$this$interceptableAdvice: com.github.kitakkun.aspectk.core.AroundScope<kotlin.String> declared in <root>.Uppercaser.aroundGreet.<anonymous>' type=com.github.kitakkun.aspectk.core.AroundScope<kotlin.String> origin=IMPLICIT_ARGUMENT
+                    ARG index: CONST Int type=kotlin.Int value=0
+                    ARG value: CALL 'public final fun uppercase (<this>: kotlin.String): kotlin.String declared in kotlin.text' type=kotlin.String origin=null
+                      ARG <this>: GET_VAR 'name: kotlin.String declared in <root>.Uppercaser.aroundGreet' type=kotlin.String origin=null
+                  RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$interceptableAdvice: com.github.kitakkun.aspectk.core.AroundScope<kotlin.String>): kotlin.String declared in <root>.Uppercaser.aroundGreet'
+                    CALL 'public final fun proceed (): R of com.github.kitakkun.aspectk.core.AroundScope declared in com.github.kitakkun.aspectk.core.AroundScope' type=kotlin.String origin=null
+                      ARG <this>: GET_VAR '$this$interceptableAdvice: com.github.kitakkun.aspectk.core.AroundScope<kotlin.String> declared in <root>.Uppercaser.aroundGreet.<anonymous>' type=com.github.kitakkun.aspectk.core.AroundScope<kotlin.String> origin=IMPLICIT_ARGUMENT
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:result type:kotlin.String [val]
+        CALL 'public final fun greet (name: kotlin.String): kotlin.String declared in <root>.Greeter' type=kotlin.String origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Greeter' type=<root>.Greeter origin=null
+          ARG name: CONST String type=kotlin.String value="world"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: GET_VAR 'val result: kotlin.String declared in <root>.box' type=kotlin.String origin=null
+              ARG arg1: CONST String type=kotlin.String value="hello WORLD"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: greet returned '"
+              GET_VAR 'val result: kotlin.String declared in <root>.box' type=kotlin.String origin=null
+              CONST String type=kotlin.String value="'"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/aroundReplaceValueParameter.kt
+++ b/aspectk-compiler/testData/box/aroundReplaceValueParameter.kt
@@ -1,0 +1,31 @@
+// FILE: AroundReplaceValueParameter.kt
+
+import com.github.kitakkun.aspectk.annotations.Around
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.ValueParameter
+import com.github.kitakkun.aspectk.core.interceptableAdvice
+
+class Greeter {
+    fun greet(name: String): String = "hello $name"
+}
+
+@Aspect
+class Uppercaser {
+    @Around
+    @ClassName("Greeter")
+    @MethodName("greet")
+    fun aroundGreet(
+        @ValueParameter(0) name: String,
+    ): String = interceptableAdvice {
+        replaceValueParameter(0, name.uppercase())
+        proceed()
+    }
+}
+
+fun box(): String {
+    val result = Greeter().greet("world")
+    if (result != "hello WORLD") return "FAIL: greet returned '$result'"
+    return "OK"
+}

--- a/aspectk-compiler/testData/box/bindingExtraction.fir.ir.txt
+++ b/aspectk-compiler/testData/box/bindingExtraction.fir.ir.txt
@@ -1,0 +1,135 @@
+FILE fqName:<root> fileName:/BindingExtraction.kt
+  PROPERTY name:observedReceiverClass visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:observedReceiverClass type:kotlin.String visibility:private [static]
+      EXPRESSION_BODY
+        CONST String type=kotlin.String value=""
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-observedReceiverClass> visibility:public modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:observedReceiverClass visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-observedReceiverClass> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:observedReceiverClass type:kotlin.String visibility:private [static]' type=kotlin.String origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-observedReceiverClass> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.String
+      correspondingProperty: PROPERTY name:observedReceiverClass visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:observedReceiverClass type:kotlin.String visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.String declared in <root>.<set-observedReceiverClass>' type=kotlin.String origin=null
+  PROPERTY name:observedName visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:observedName type:kotlin.String visibility:private [static]
+      EXPRESSION_BODY
+        CONST String type=kotlin.String value=""
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-observedName> visibility:public modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:observedName visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-observedName> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:observedName type:kotlin.String visibility:private [static]' type=kotlin.String origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-observedName> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.String
+      correspondingProperty: PROPERTY name:observedName visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:observedName type:kotlin.String visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.String declared in <root>.<set-observedName>' type=kotlin.String origin=null
+  CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Greeter
+    CONSTRUCTOR visibility:public returnType:<root>.Greeter [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:greet visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Greeter
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+      BLOCK_BODY
+        CALL 'public final fun beforeGreet (greeter: <root>.Greeter, name: kotlin.String): kotlin.Unit declared in <root>.GreetingObserver' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.GreetingObserver' type=<root>.GreetingObserver origin=null
+          ARG greeter: GET_VAR '<this>: <root>.Greeter declared in <root>.Greeter.greet' type=<root>.Greeter origin=null
+          ARG name: GET_VAR 'name: kotlin.String declared in <root>.Greeter.greet' type=kotlin.String origin=null
+        RETURN type=kotlin.Nothing from='public final fun greet (name: kotlin.String): kotlin.String declared in <root>.Greeter'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="hello "
+            GET_VAR 'name: kotlin.String declared in <root>.Greeter.greet' type=kotlin.String origin=null
+  CLASS CLASS name:GreetingObserver modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.GreetingObserver
+    CONSTRUCTOR visibility:public returnType:<root>.GreetingObserver [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:GreetingObserver modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeGreet visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.GreetingObserver
+      VALUE_PARAMETER kind:Regular name:greeter index:1 type:<root>.Greeter
+        annotations:
+          DispatchReceiver
+      VALUE_PARAMETER kind:Regular name:name index:2 type:kotlin.String
+        annotations:
+          ValueParameter(index = 0, name = <null>)
+      annotations:
+        Before
+        ClassName(pattern = "Greeter")
+        MethodName(pattern = "greet")
+      BLOCK_BODY
+        CALL 'public final fun <set-observedReceiverClass> (<set-?>: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+          ARG <set-?>: TYPE_OP type=kotlin.String origin=IMPLICIT_NOTNULL typeOperand=kotlin.String
+            CALL 'public open fun getSimpleName (): @[FlexibleNullability] kotlin.String? declared in java.lang.Class' type=@[FlexibleNullability] kotlin.String? origin=GET_PROPERTY
+              ARG <this>: CALL 'public final fun <get-java> <T> (<this>: kotlin.reflect.KClass<T of kotlin.jvm.<get-java>>): java.lang.Class<T of kotlin.jvm.<get-java>> declared in kotlin.jvm' type=java.lang.Class<out <root>.Greeter> origin=GET_PROPERTY
+                TYPE_ARG T: <root>.Greeter
+                ARG <this>: GET_CLASS type=kotlin.reflect.KClass<out <root>.Greeter>
+                  GET_VAR 'greeter: <root>.Greeter declared in <root>.GreetingObserver.beforeGreet' type=<root>.Greeter origin=null
+        CALL 'public final fun <set-observedName> (<set-?>: kotlin.String): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+          ARG <set-?>: GET_VAR 'name: kotlin.String declared in <root>.GreetingObserver.beforeGreet' type=kotlin.String origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun greet (name: kotlin.String): kotlin.String declared in <root>.Greeter' type=kotlin.String origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Greeter' type=<root>.Greeter origin=null
+          ARG name: CONST String type=kotlin.String value="world"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-observedReceiverClass> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              ARG arg1: CONST String type=kotlin.String value="Greeter"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: receiver='"
+              CALL 'public final fun <get-observedReceiverClass> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              CONST String type=kotlin.String value="'"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-observedName> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              ARG arg1: CONST String type=kotlin.String value="world"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: name='"
+              CALL 'public final fun <get-observedName> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+              CONST String type=kotlin.String value="'"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/bindingExtraction.kt
+++ b/aspectk-compiler/testData/box/bindingExtraction.kt
@@ -1,0 +1,36 @@
+// FILE: BindingExtraction.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.DispatchReceiver
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.ValueParameter
+
+var observedReceiverClass: String = ""
+var observedName: String = ""
+
+class Greeter {
+    fun greet(name: String): String = "hello $name"
+}
+
+@Aspect
+class GreetingObserver {
+    @Before
+    @ClassName("Greeter")
+    @MethodName("greet")
+    fun beforeGreet(
+        @DispatchReceiver greeter: Greeter,
+        @ValueParameter(0) name: String,
+    ) {
+        observedReceiverClass = greeter::class.java.simpleName
+        observedName = name
+    }
+}
+
+fun box(): String {
+    Greeter().greet("world")
+    if (observedReceiverClass != "Greeter") return "FAIL: receiver='$observedReceiverClass'"
+    if (observedName != "world") return "FAIL: name='$observedName'"
+    return "OK"
+}

--- a/aspectk-compiler/testData/diagnostics/bindingAnnotationBothIndexAndName.fir.txt
+++ b/aspectk-compiler/testData/diagnostics/bindingAnnotationBothIndexAndName.fir.txt
@@ -1,0 +1,10 @@
+FILE: BindingAnnotationBothIndexAndName.kt
+    @R|com/github/kitakkun/aspectk/annotations/Aspect|() public final class Aspect : R|kotlin/Any| {
+        public constructor(): R|Aspect| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|() @R|com/github/kitakkun/aspectk/annotations/MethodName|(pattern = String(greet)) public final fun beforeGreet(@R|com/github/kitakkun/aspectk/annotations/ValueParameter|(index = Int(0), name = String(name)) name: R|kotlin/String|): R|kotlin/Unit| {
+        }
+
+    }

--- a/aspectk-compiler/testData/diagnostics/bindingAnnotationBothIndexAndName.kt
+++ b/aspectk-compiler/testData/diagnostics/bindingAnnotationBothIndexAndName.kt
@@ -1,0 +1,15 @@
+// FILE: BindingAnnotationBothIndexAndName.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.ValueParameter
+
+@Aspect
+class Aspect {
+    @Before
+    @MethodName("greet")
+    fun beforeGreet(
+        <!INVALID_BINDING_ANNOTATION!>@ValueParameter(index = 0, name = "name")<!> name: String,
+    ) {}
+}

--- a/aspectk-compiler/testData/diagnostics/bindingAnnotationMissingIndexAndName.fir.txt
+++ b/aspectk-compiler/testData/diagnostics/bindingAnnotationMissingIndexAndName.fir.txt
@@ -1,0 +1,10 @@
+FILE: BindingAnnotationMissingIndexAndName.kt
+    @R|com/github/kitakkun/aspectk/annotations/Aspect|() public final class Aspect : R|kotlin/Any| {
+        public constructor(): R|Aspect| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|() @R|com/github/kitakkun/aspectk/annotations/MethodName|(pattern = String(greet)) public final fun beforeGreet(@R|com/github/kitakkun/aspectk/annotations/ValueParameter|() name: R|kotlin/String|): R|kotlin/Unit| {
+        }
+
+    }

--- a/aspectk-compiler/testData/diagnostics/bindingAnnotationMissingIndexAndName.kt
+++ b/aspectk-compiler/testData/diagnostics/bindingAnnotationMissingIndexAndName.kt
@@ -1,0 +1,15 @@
+// FILE: BindingAnnotationMissingIndexAndName.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.ValueParameter
+
+@Aspect
+class Aspect {
+    @Before
+    @MethodName("greet")
+    fun beforeGreet(
+        <!INVALID_BINDING_ANNOTATION!>@ValueParameter<!> name: String,
+    ) {}
+}

--- a/aspectk-compiler/testData/diagnostics/emptyMethodNamePattern.fir.txt
+++ b/aspectk-compiler/testData/diagnostics/emptyMethodNamePattern.fir.txt
@@ -1,0 +1,10 @@
+FILE: EmptyMethodNamePattern.kt
+    @R|com/github/kitakkun/aspectk/annotations/Aspect|() public final class EmptyPatternAspect : R|kotlin/Any| {
+        public constructor(): R|EmptyPatternAspect| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|() @R|com/github/kitakkun/aspectk/annotations/MethodName|(pattern = String()) public final fun beforeNothing(): R|kotlin/Unit| {
+        }
+
+    }

--- a/aspectk-compiler/testData/diagnostics/emptyMethodNamePattern.kt
+++ b/aspectk-compiler/testData/diagnostics/emptyMethodNamePattern.kt
@@ -1,0 +1,12 @@
+// FILE: EmptyMethodNamePattern.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.MethodName
+
+@Aspect
+class EmptyPatternAspect {
+    @Before
+    <!INVALID_POINTCUT_ANNOTATION!>@MethodName("")<!>
+    fun beforeNothing() {}
+}


### PR DESCRIPTION
## Summary

Phase 3.5.6 of the v1 roadmap, stacked on #26 (`feat/v1-phase3.5.5-test-harness`).

Builds on the Phase 3.5.5 test harness. Adds three diagnostic fixtures and four box fixtures so the existing v1 features get automated regression coverage instead of relying on the manually invoked `test/` sample module.

### New diagnostic fixtures

| File | Verifies |
|---|---|
| `emptyMethodNamePattern.kt` | `PointcutAnnotationChecker` emits `INVALID_POINTCUT_ANNOTATION` on `` `@MethodName("")` `` |
| `bindingAnnotationMissingIndexAndName.kt` | `BindingAnnotationChecker` emits `INVALID_BINDING_ANNOTATION` on `` `@ValueParameter` `` with no args |
| `bindingAnnotationBothIndexAndName.kt` | Same diagnostic when `` `@ValueParameter(index = 0, name = "name")` `` specifies both |

### New box fixtures

| File | Verifies |
|---|---|
| `afterAdvice.kt` | `` `@After` `` wraps the target in `try { … } finally { … }` and trace order is `[body][after]` |
| `aroundAdviceProceed.kt` | `` `@Around` `` with `interceptableAdvice { … proceed() … }` wraps the call; `proceed()` returns the original body's value |
| `aroundReplaceValueParameter.kt` | `replaceValueParameter(0, name.uppercase())` rewrites the local override slot so `proceed()` runs the body with the uppercased arg |
| `bindingExtraction.kt` | `` `@DispatchReceiver greeter: Greeter` `` extracts the dispatch receiver; `` `@ValueParameter(0) name: String` `` extracts the first value argument |

Each fixture has its companion `.fir.txt` / `.fir.ir.txt` golden generated by the framework and committed.

## Test plan

- [x] `./gradlew :aspectk-compiler:test` — 11 tests green (5 diagnostic + 6 box).
- [x] Removing the diagnostic marker from one fixture and re-running confirms the harness actually exercises each checker (not just silently passes).