### PR TITLE
Phase 3.5.7: box coverage for matching annotations (@Visibility / @Modifiers / @Annotated / @Package)

### DIFF
--- a/aspectk-compiler/testData/box/annotatedMatching.fir.ir.txt
+++ b/aspectk-compiler/testData/box/annotatedMatching.fir.ir.txt
@@ -1,0 +1,124 @@
+FILE fqName:<root> fileName:/AnnotatedMatching.kt
+  PROPERTY name:loggableHits visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:loggableHits type:kotlin.Int visibility:private [static]
+      EXPRESSION_BODY
+        CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-loggableHits> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:loggableHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-loggableHits> (): kotlin.Int declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:loggableHits type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-loggableHits> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:loggableHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:loggableHits type:kotlin.Int visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.Int declared in <root>.<set-loggableHits>' type=kotlin.Int origin=null
+  CLASS ANNOTATION_CLASS name:Loggable modality:OPEN visibility:public superTypes:[kotlin.Annotation]
+    annotations:
+      Retention(value = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RUNTIME' type=kotlin.annotation.AnnotationRetention)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Loggable
+    CONSTRUCTOR visibility:public returnType:<root>.Loggable [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS ANNOTATION_CLASS name:Loggable modality:OPEN visibility:public superTypes:[kotlin.Annotation]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Annotation
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Annotation
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Annotation
+  CLASS CLASS name:LoggingAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.LoggingAspect
+    CONSTRUCTOR visibility:public returnType:<root>.LoggingAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:LoggingAspect modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeLoggable visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.LoggingAspect
+      annotations:
+        Before
+        ClassName(pattern = "Service")
+        MethodName(pattern = "*Action")
+        Annotated(values = [CLASS_REFERENCE 'CLASS ANNOTATION_CLASS name:Loggable modality:OPEN visibility:public superTypes:[kotlin.Annotation]' type=kotlin.reflect.KClass<<root>.Loggable>] type=kotlin.Array<out kotlin.reflect.KClass<out kotlin.Annotation>> varargElementType=kotlin.reflect.KClass<out kotlin.Annotation>)
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
+              CALL 'public final fun <get-loggableHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=POSTFIX_INCR
+            CALL 'public final fun <set-loggableHits> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_0: kotlin.Int declared in <root>.LoggingAspect.beforeLoggable' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_0: kotlin.Int declared in <root>.LoggingAspect.beforeLoggable' type=kotlin.Int origin=null
+  CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Service
+    CONSTRUCTOR visibility:public returnType:<root>.Service [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:loggableAction visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Service
+      annotations:
+        Loggable
+      BLOCK_BODY
+        CALL 'public final fun beforeLoggable (): kotlin.Unit declared in <root>.LoggingAspect' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.LoggingAspect' type=<root>.LoggingAspect origin=null
+    FUN name:silentAction visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Service
+      BLOCK_BODY
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:s type:<root>.Service [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Service' type=<root>.Service origin=null
+      CALL 'public final fun loggableAction (): kotlin.Unit declared in <root>.Service' type=kotlin.Unit origin=null
+        ARG <this>: GET_VAR 'val s: <root>.Service declared in <root>.box' type=<root>.Service origin=null
+      CALL 'public final fun silentAction (): kotlin.Unit declared in <root>.Service' type=kotlin.Unit origin=null
+        ARG <this>: GET_VAR 'val s: <root>.Service declared in <root>.box' type=<root>.Service origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-loggableHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: loggableHits="
+              CALL 'public final fun <get-loggableHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value=" (expected 1, only @Loggable should match)"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/annotatedMatching.kt
+++ b/aspectk-compiler/testData/box/annotatedMatching.kt
@@ -1,0 +1,37 @@
+// FILE: AnnotatedMatching.kt
+
+import com.github.kitakkun.aspectk.annotations.Annotated
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.MethodName
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Loggable
+
+var loggableHits = 0
+
+class Service {
+    @Loggable
+    fun loggableAction() {}
+    fun silentAction() {}
+}
+
+@Aspect
+class LoggingAspect {
+    @Before
+    @ClassName("Service")
+    @MethodName("*Action")
+    @Annotated(Loggable::class)
+    fun beforeLoggable() {
+        loggableHits++
+    }
+}
+
+fun box(): String {
+    val s = Service()
+    s.loggableAction()
+    s.silentAction()
+    if (loggableHits != 1) return "FAIL: loggableHits=$loggableHits (expected 1, only @Loggable should match)"
+    return "OK"
+}

--- a/aspectk-compiler/testData/box/modalityMatching.fir.ir.txt
+++ b/aspectk-compiler/testData/box/modalityMatching.fir.ir.txt
@@ -1,0 +1,181 @@
+FILE fqName:<root> fileName:/ModalityMatching.kt
+  PROPERTY name:openHits visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:openHits type:kotlin.Int visibility:private [static]
+      EXPRESSION_BODY
+        CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-openHits> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:openHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-openHits> (): kotlin.Int declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:openHits type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-openHits> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:openHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:openHits type:kotlin.Int visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.Int declared in <root>.<set-openHits>' type=kotlin.Int origin=null
+  PROPERTY name:finalHits visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:finalHits type:kotlin.Int visibility:private [static]
+      EXPRESSION_BODY
+        CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-finalHits> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:finalHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-finalHits> (): kotlin.Int declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:finalHits type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-finalHits> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:finalHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:finalHits type:kotlin.Int visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.Int declared in <root>.<set-finalHits>' type=kotlin.Int origin=null
+  CLASS CLASS name:FinalOnlyAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.FinalOnlyAspect
+    CONSTRUCTOR visibility:public returnType:<root>.FinalOnlyAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FinalOnlyAspect modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeFinalTouch visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.FinalOnlyAspect
+      annotations:
+        Before
+        MethodName(pattern = "touch")
+        Modality(values = [GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:FINAL' type=com.github.kitakkun.aspectk.annotations.Modality.Kind] type=kotlin.Array<out com.github.kitakkun.aspectk.annotations.Modality.Kind> varargElementType=com.github.kitakkun.aspectk.annotations.Modality.Kind)
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
+              CALL 'public final fun <get-finalHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=POSTFIX_INCR
+            CALL 'public final fun <set-finalHits> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_0: kotlin.Int declared in <root>.FinalOnlyAspect.beforeFinalTouch' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_0: kotlin.Int declared in <root>.FinalOnlyAspect.beforeFinalTouch' type=kotlin.Int origin=null
+  CLASS CLASS name:FinalOwner modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.FinalOwner
+    CONSTRUCTOR visibility:public returnType:<root>.FinalOwner [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FinalOwner modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:touch visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.FinalOwner
+      BLOCK_BODY
+        CALL 'public final fun beforeFinalTouch (): kotlin.Unit declared in <root>.FinalOnlyAspect' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.FinalOnlyAspect' type=<root>.FinalOnlyAspect origin=null
+  CLASS CLASS name:OpenOnlyAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.OpenOnlyAspect
+    CONSTRUCTOR visibility:public returnType:<root>.OpenOnlyAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:OpenOnlyAspect modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeOpenTouch visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OpenOnlyAspect
+      annotations:
+        Before
+        MethodName(pattern = "touch")
+        Modality(values = [GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:OPEN' type=com.github.kitakkun.aspectk.annotations.Modality.Kind] type=kotlin.Array<out com.github.kitakkun.aspectk.annotations.Modality.Kind> varargElementType=com.github.kitakkun.aspectk.annotations.Modality.Kind)
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
+              CALL 'public final fun <get-openHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=POSTFIX_INCR
+            CALL 'public final fun <set-openHits> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_1: kotlin.Int declared in <root>.OpenOnlyAspect.beforeOpenTouch' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_1: kotlin.Int declared in <root>.OpenOnlyAspect.beforeOpenTouch' type=kotlin.Int origin=null
+  CLASS CLASS name:OpenOwner modality:OPEN visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.OpenOwner
+    CONSTRUCTOR visibility:public returnType:<root>.OpenOwner [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:OpenOwner modality:OPEN visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:touch visibility:public modality:OPEN returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OpenOwner
+      BLOCK_BODY
+        CALL 'public final fun beforeOpenTouch (): kotlin.Unit declared in <root>.OpenOnlyAspect' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.OpenOnlyAspect' type=<root>.OpenOnlyAspect origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public open fun touch (): kotlin.Unit declared in <root>.OpenOwner' type=kotlin.Unit origin=null
+        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.OpenOwner' type=<root>.OpenOwner origin=null
+      CALL 'public final fun touch (): kotlin.Unit declared in <root>.FinalOwner' type=kotlin.Unit origin=null
+        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.FinalOwner' type=<root>.FinalOwner origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-openHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: openHits="
+              CALL 'public final fun <get-openHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value=" (expected 1)"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-finalHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: finalHits="
+              CALL 'public final fun <get-finalHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value=" (expected 1)"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/modalityMatching.kt
+++ b/aspectk-compiler/testData/box/modalityMatching.kt
@@ -1,0 +1,45 @@
+// FILE: ModalityMatching.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.Modality
+
+var openHits = 0
+var finalHits = 0
+
+open class OpenOwner {
+    open fun touch() {}
+}
+
+class FinalOwner {
+    fun touch() {}
+}
+
+@Aspect
+class OpenOnlyAspect {
+    @Before
+    @MethodName("touch")
+    @Modality(Modality.Kind.OPEN)
+    fun beforeOpenTouch() {
+        openHits++
+    }
+}
+
+@Aspect
+class FinalOnlyAspect {
+    @Before
+    @MethodName("touch")
+    @Modality(Modality.Kind.FINAL)
+    fun beforeFinalTouch() {
+        finalHits++
+    }
+}
+
+fun box(): String {
+    OpenOwner().touch()
+    FinalOwner().touch()
+    if (openHits != 1) return "FAIL: openHits=$openHits (expected 1)"
+    if (finalHits != 1) return "FAIL: finalHits=$finalHits (expected 1)"
+    return "OK"
+}

--- a/aspectk-compiler/testData/box/modalityMatchingOpenClassFinalFun.fir.ir.txt
+++ b/aspectk-compiler/testData/box/modalityMatchingOpenClassFinalFun.fir.ir.txt
@@ -1,0 +1,157 @@
+FILE fqName:<root> fileName:/ModalityMatchingOpenClassFinalFun.kt
+  PROPERTY name:openHits visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:openHits type:kotlin.Int visibility:private [static]
+      EXPRESSION_BODY
+        CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-openHits> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:openHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-openHits> (): kotlin.Int declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:openHits type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-openHits> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:openHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:openHits type:kotlin.Int visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.Int declared in <root>.<set-openHits>' type=kotlin.Int origin=null
+  PROPERTY name:finalHits visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:finalHits type:kotlin.Int visibility:private [static]
+      EXPRESSION_BODY
+        CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-finalHits> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:finalHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-finalHits> (): kotlin.Int declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:finalHits type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-finalHits> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:finalHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:finalHits type:kotlin.Int visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.Int declared in <root>.<set-finalHits>' type=kotlin.Int origin=null
+  CLASS CLASS name:FinalAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.FinalAspect
+    CONSTRUCTOR visibility:public returnType:<root>.FinalAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FinalAspect modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeFinal visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.FinalAspect
+      annotations:
+        Before
+        MethodName(pattern = "touch")
+        Modality(values = [GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:FINAL' type=com.github.kitakkun.aspectk.annotations.Modality.Kind] type=kotlin.Array<out com.github.kitakkun.aspectk.annotations.Modality.Kind> varargElementType=com.github.kitakkun.aspectk.annotations.Modality.Kind)
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
+              CALL 'public final fun <get-finalHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=POSTFIX_INCR
+            CALL 'public final fun <set-finalHits> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_0: kotlin.Int declared in <root>.FinalAspect.beforeFinal' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_0: kotlin.Int declared in <root>.FinalAspect.beforeFinal' type=kotlin.Int origin=null
+  CLASS CLASS name:Mixed modality:OPEN visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Mixed
+    CONSTRUCTOR visibility:public returnType:<root>.Mixed [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Mixed modality:OPEN visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:touch visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Mixed
+      BLOCK_BODY
+        CALL 'public final fun beforeFinal (): kotlin.Unit declared in <root>.FinalAspect' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.FinalAspect' type=<root>.FinalAspect origin=null
+        CALL 'public final fun beforeOpen (): kotlin.Unit declared in <root>.OpenAspect' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.OpenAspect' type=<root>.OpenAspect origin=null
+  CLASS CLASS name:OpenAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.OpenAspect
+    CONSTRUCTOR visibility:public returnType:<root>.OpenAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:OpenAspect modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeOpen visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OpenAspect
+      annotations:
+        Before
+        MethodName(pattern = "touch")
+        Modality(values = [GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:OPEN' type=com.github.kitakkun.aspectk.annotations.Modality.Kind] type=kotlin.Array<out com.github.kitakkun.aspectk.annotations.Modality.Kind> varargElementType=com.github.kitakkun.aspectk.annotations.Modality.Kind)
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
+              CALL 'public final fun <get-openHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=POSTFIX_INCR
+            CALL 'public final fun <set-openHits> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_1: kotlin.Int declared in <root>.OpenAspect.beforeOpen' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_1: kotlin.Int declared in <root>.OpenAspect.beforeOpen' type=kotlin.Int origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun touch (): kotlin.Unit declared in <root>.Mixed' type=kotlin.Unit origin=null
+        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Mixed' type=<root>.Mixed origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-openHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: openHits="
+              CALL 'public final fun <get-openHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value=" (expected 1 — open class should match OPEN)"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-finalHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: finalHits="
+              CALL 'public final fun <get-finalHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value=" (expected 1 — final fun should match FINAL)"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/modalityMatchingOpenClassFinalFun.kt
+++ b/aspectk-compiler/testData/box/modalityMatchingOpenClassFinalFun.kt
@@ -1,0 +1,45 @@
+// FILE: ModalityMatchingOpenClassFinalFun.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.Modality
+
+// Verifies the "enclosing class OR function-own" semantic for @Modality:
+// touch() is FINAL (default member fun), but its enclosing class is OPEN.
+// Per Modality.kt KDoc ("OPEN matches open class and open fun parents"),
+// both @Modality(OPEN) and @Modality(FINAL) must hit this target.
+
+var openHits = 0
+var finalHits = 0
+
+open class Mixed {
+    fun touch() {}
+}
+
+@Aspect
+class OpenAspect {
+    @Before
+    @MethodName("touch")
+    @Modality(Modality.Kind.OPEN)
+    fun beforeOpen() {
+        openHits++
+    }
+}
+
+@Aspect
+class FinalAspect {
+    @Before
+    @MethodName("touch")
+    @Modality(Modality.Kind.FINAL)
+    fun beforeFinal() {
+        finalHits++
+    }
+}
+
+fun box(): String {
+    Mixed().touch()
+    if (openHits != 1) return "FAIL: openHits=$openHits (expected 1 — open class should match OPEN)"
+    if (finalHits != 1) return "FAIL: finalHits=$finalHits (expected 1 — final fun should match FINAL)"
+    return "OK"
+}

--- a/aspectk-compiler/testData/box/modifiersMatching.fir.ir.txt
+++ b/aspectk-compiler/testData/box/modifiersMatching.fir.ir.txt
@@ -1,0 +1,167 @@
+FILE fqName:<root> fileName:/ModifiersMatching.kt
+  PROPERTY name:inlineHits visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:inlineHits type:kotlin.Int visibility:private [static]
+      EXPRESSION_BODY
+        CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-inlineHits> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:inlineHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-inlineHits> (): kotlin.Int declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:inlineHits type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-inlineHits> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:inlineHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:inlineHits type:kotlin.Int visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.Int declared in <root>.<set-inlineHits>' type=kotlin.Int origin=null
+  PROPERTY name:nonInlineHits visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:nonInlineHits type:kotlin.Int visibility:private [static]
+      EXPRESSION_BODY
+        CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-nonInlineHits> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:nonInlineHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-nonInlineHits> (): kotlin.Int declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nonInlineHits type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-nonInlineHits> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:nonInlineHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nonInlineHits type:kotlin.Int visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.Int declared in <root>.<set-nonInlineHits>' type=kotlin.Int origin=null
+  CLASS CLASS name:CatchAllAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.CatchAllAspect
+    CONSTRUCTOR visibility:public returnType:<root>.CatchAllAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:CatchAllAspect modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeAny visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.CatchAllAspect
+      annotations:
+        Before
+        ClassName(pattern = "Util")
+        MethodName(pattern = "*Do")
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
+              CALL 'public final fun <get-nonInlineHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=POSTFIX_INCR
+            CALL 'public final fun <set-nonInlineHits> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_0: kotlin.Int declared in <root>.CatchAllAspect.beforeAny' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_0: kotlin.Int declared in <root>.CatchAllAspect.beforeAny' type=kotlin.Int origin=null
+  CLASS CLASS name:InlineOnlyAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.InlineOnlyAspect
+    CONSTRUCTOR visibility:public returnType:<root>.InlineOnlyAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:InlineOnlyAspect modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeInline visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.InlineOnlyAspect
+      annotations:
+        Before
+        ClassName(pattern = "Util")
+        MethodName(pattern = "*Do")
+        Modifiers(values = [GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:INLINE' type=com.github.kitakkun.aspectk.annotations.Modifiers.Kind] type=kotlin.Array<out com.github.kitakkun.aspectk.annotations.Modifiers.Kind> varargElementType=com.github.kitakkun.aspectk.annotations.Modifiers.Kind)
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
+              CALL 'public final fun <get-inlineHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=POSTFIX_INCR
+            CALL 'public final fun <set-inlineHits> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_1: kotlin.Int declared in <root>.InlineOnlyAspect.beforeInline' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_1: kotlin.Int declared in <root>.InlineOnlyAspect.beforeInline' type=kotlin.Int origin=null
+  CLASS CLASS name:Util modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Util
+    CONSTRUCTOR visibility:public returnType:<root>.Util [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Util modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:inlineDo visibility:public modality:FINAL returnType:kotlin.Unit [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Util
+      BLOCK_BODY
+        CALL 'public final fun beforeAny (): kotlin.Unit declared in <root>.CatchAllAspect' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.CatchAllAspect' type=<root>.CatchAllAspect origin=null
+        CALL 'public final fun beforeInline (): kotlin.Unit declared in <root>.InlineOnlyAspect' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.InlineOnlyAspect' type=<root>.InlineOnlyAspect origin=null
+    FUN name:normalDo visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Util
+      BLOCK_BODY
+        CALL 'public final fun beforeAny (): kotlin.Unit declared in <root>.CatchAllAspect' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.CatchAllAspect' type=<root>.CatchAllAspect origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:u type:<root>.Util [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Util' type=<root>.Util origin=null
+      CALL 'public final fun normalDo (): kotlin.Unit declared in <root>.Util' type=kotlin.Unit origin=null
+        ARG <this>: GET_VAR 'val u: <root>.Util declared in <root>.box' type=<root>.Util origin=null
+      CALL 'public final fun inlineDo (): kotlin.Unit declared in <root>.Util' type=kotlin.Unit origin=null
+        ARG <this>: GET_VAR 'val u: <root>.Util declared in <root>.box' type=<root>.Util origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-inlineHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: inlineHits="
+              CALL 'public final fun <get-inlineHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value=" (expected 1)"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-nonInlineHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg1: CONST Int type=kotlin.Int value=2
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: nonInlineHits="
+              CALL 'public final fun <get-nonInlineHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value=" (expected 2)"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/modifiersMatching.kt
+++ b/aspectk-compiler/testData/box/modifiersMatching.kt
@@ -1,0 +1,46 @@
+// FILE: ModifiersMatching.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.Modifiers
+
+var inlineHits = 0
+var nonInlineHits = 0
+
+class Util {
+    fun normalDo() {}
+    inline fun inlineDo() {}
+}
+
+@Aspect
+class InlineOnlyAspect {
+    @Before
+    @ClassName("Util")
+    @MethodName("*Do")
+    @Modifiers(Modifiers.Kind.INLINE)
+    fun beforeInline() {
+        inlineHits++
+    }
+}
+
+@Aspect
+class CatchAllAspect {
+    @Before
+    @ClassName("Util")
+    @MethodName("*Do")
+    fun beforeAny() {
+        nonInlineHits++
+    }
+}
+
+fun box(): String {
+    val u = Util()
+    u.normalDo()
+    u.inlineDo()
+    // CatchAllAspect should match both, InlineOnlyAspect only inlineDo.
+    if (inlineHits != 1) return "FAIL: inlineHits=$inlineHits (expected 1)"
+    if (nonInlineHits != 2) return "FAIL: nonInlineHits=$nonInlineHits (expected 2)"
+    return "OK"
+}

--- a/aspectk-compiler/testData/box/packageMatching.fir.ir.txt
+++ b/aspectk-compiler/testData/box/packageMatching.fir.ir.txt
@@ -1,0 +1,93 @@
+FILE fqName:com.example.app fileName:/PackageMatching.kt
+  PROPERTY name:hits visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:hits type:kotlin.Int visibility:private [static]
+      EXPRESSION_BODY
+        CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-hits> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:hits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-hits> (): kotlin.Int declared in com.example.app'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:hits type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-hits> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:hits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:hits type:kotlin.Int visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.Int declared in com.example.app.<set-hits>' type=kotlin.Int origin=null
+  CLASS CLASS name:Owner modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:com.example.app.Owner
+    CONSTRUCTOR visibility:public returnType:com.example.app.Owner [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Owner modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:touch visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:com.example.app.Owner
+      BLOCK_BODY
+        CALL 'public final fun beforeTouch (): kotlin.Unit declared in com.example.app.PackageAspect' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in com.example.app.PackageAspect' type=com.example.app.PackageAspect origin=null
+  CLASS CLASS name:PackageAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:com.example.app.PackageAspect
+    CONSTRUCTOR visibility:public returnType:com.example.app.PackageAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:PackageAspect modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeTouch visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:com.example.app.PackageAspect
+      annotations:
+        Before
+        Package(pattern = "com.example.**")
+        MethodName(pattern = "touch")
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
+              CALL 'public final fun <get-hits> (): kotlin.Int declared in com.example.app' type=kotlin.Int origin=POSTFIX_INCR
+            CALL 'public final fun <set-hits> (<set-?>: kotlin.Int): kotlin.Unit declared in com.example.app' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_0: kotlin.Int declared in com.example.app.PackageAspect.beforeTouch' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_0: kotlin.Int declared in com.example.app.PackageAspect.beforeTouch' type=kotlin.Int origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun touch (): kotlin.Unit declared in com.example.app.Owner' type=kotlin.Unit origin=null
+        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in com.example.app.Owner' type=com.example.app.Owner origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-hits> (): kotlin.Int declared in com.example.app' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in com.example.app'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: hits="
+              CALL 'public final fun <get-hits> (): kotlin.Int declared in com.example.app' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value=" (expected 1)"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in com.example.app'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/packageMatching.kt
+++ b/aspectk-compiler/testData/box/packageMatching.kt
@@ -1,0 +1,30 @@
+// FILE: PackageMatching.kt
+
+package com.example.app
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.Package
+
+var hits = 0
+
+class Owner {
+    fun touch() {}
+}
+
+@Aspect
+class PackageAspect {
+    @Before
+    @Package("com.example.**")
+    @MethodName("touch")
+    fun beforeTouch() {
+        hits++
+    }
+}
+
+fun box(): String {
+    Owner().touch()
+    if (hits != 1) return "FAIL: hits=$hits (expected 1)"
+    return "OK"
+}

--- a/aspectk-compiler/testData/box/visibilityMatching.fir.ir.txt
+++ b/aspectk-compiler/testData/box/visibilityMatching.fir.ir.txt
@@ -1,0 +1,166 @@
+FILE fqName:<root> fileName:/VisibilityMatching.kt
+  PROPERTY name:publicHits visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:publicHits type:kotlin.Int visibility:private [static]
+      EXPRESSION_BODY
+        CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-publicHits> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:publicHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-publicHits> (): kotlin.Int declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:publicHits type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-publicHits> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:publicHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:publicHits type:kotlin.Int visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.Int declared in <root>.<set-publicHits>' type=kotlin.Int origin=null
+  PROPERTY name:internalHits visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:internalHits type:kotlin.Int visibility:private [static]
+      EXPRESSION_BODY
+        CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-internalHits> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:internalHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-internalHits> (): kotlin.Int declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:internalHits type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-internalHits> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:internalHits visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:internalHits type:kotlin.Int visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.Int declared in <root>.<set-internalHits>' type=kotlin.Int origin=null
+  CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Greeter
+    CONSTRUCTOR visibility:public returnType:<root>.Greeter [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:internalGreet visibility:internal modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Greeter
+      BLOCK_BODY
+        CALL 'public final fun beforeInternal (): kotlin.Unit declared in <root>.InternalOnlyAspect' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.InternalOnlyAspect' type=<root>.InternalOnlyAspect origin=null
+    FUN name:publicGreet visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Greeter
+      BLOCK_BODY
+        CALL 'public final fun beforePublic (): kotlin.Unit declared in <root>.PublicOnlyAspect' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.PublicOnlyAspect' type=<root>.PublicOnlyAspect origin=null
+  CLASS CLASS name:InternalOnlyAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.InternalOnlyAspect
+    CONSTRUCTOR visibility:public returnType:<root>.InternalOnlyAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:InternalOnlyAspect modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeInternal visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.InternalOnlyAspect
+      annotations:
+        Before
+        ClassName(pattern = "Greeter")
+        MethodName(pattern = "*Greet")
+        Visibility(values = [GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:INTERNAL' type=com.github.kitakkun.aspectk.annotations.Visibility.Kind] type=kotlin.Array<out com.github.kitakkun.aspectk.annotations.Visibility.Kind> varargElementType=com.github.kitakkun.aspectk.annotations.Visibility.Kind)
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
+              CALL 'public final fun <get-internalHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=POSTFIX_INCR
+            CALL 'public final fun <set-internalHits> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_0: kotlin.Int declared in <root>.InternalOnlyAspect.beforeInternal' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_0: kotlin.Int declared in <root>.InternalOnlyAspect.beforeInternal' type=kotlin.Int origin=null
+  CLASS CLASS name:PublicOnlyAspect modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.PublicOnlyAspect
+    CONSTRUCTOR visibility:public returnType:<root>.PublicOnlyAspect [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:PublicOnlyAspect modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforePublic visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.PublicOnlyAspect
+      annotations:
+        Before
+        ClassName(pattern = "Greeter")
+        MethodName(pattern = "*Greet")
+        Visibility(values = [GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:PUBLIC' type=com.github.kitakkun.aspectk.annotations.Visibility.Kind] type=kotlin.Array<out com.github.kitakkun.aspectk.annotations.Visibility.Kind> varargElementType=com.github.kitakkun.aspectk.annotations.Visibility.Kind)
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
+              CALL 'public final fun <get-publicHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=POSTFIX_INCR
+            CALL 'public final fun <set-publicHits> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_1: kotlin.Int declared in <root>.PublicOnlyAspect.beforePublic' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_1: kotlin.Int declared in <root>.PublicOnlyAspect.beforePublic' type=kotlin.Int origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:g type:<root>.Greeter [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Greeter' type=<root>.Greeter origin=null
+      CALL 'public final fun publicGreet (): kotlin.Unit declared in <root>.Greeter' type=kotlin.Unit origin=null
+        ARG <this>: GET_VAR 'val g: <root>.Greeter declared in <root>.box' type=<root>.Greeter origin=null
+      CALL 'internal final fun internalGreet (): kotlin.Unit declared in <root>.Greeter' type=kotlin.Unit origin=null
+        ARG <this>: GET_VAR 'val g: <root>.Greeter declared in <root>.box' type=<root>.Greeter origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-publicHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: publicHits="
+              CALL 'public final fun <get-publicHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value=" (expected 1)"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-internalHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: internalHits="
+              CALL 'public final fun <get-internalHits> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value=" (expected 1)"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/visibilityMatching.kt
+++ b/aspectk-compiler/testData/box/visibilityMatching.kt
@@ -1,0 +1,46 @@
+// FILE: VisibilityMatching.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.Visibility
+
+var publicHits = 0
+var internalHits = 0
+
+class Greeter {
+    fun publicGreet() {}
+    internal fun internalGreet() {}
+}
+
+@Aspect
+class PublicOnlyAspect {
+    @Before
+    @ClassName("Greeter")
+    @MethodName("*Greet")
+    @Visibility(Visibility.Kind.PUBLIC)
+    fun beforePublic() {
+        publicHits++
+    }
+}
+
+@Aspect
+class InternalOnlyAspect {
+    @Before
+    @ClassName("Greeter")
+    @MethodName("*Greet")
+    @Visibility(Visibility.Kind.INTERNAL)
+    fun beforeInternal() {
+        internalHits++
+    }
+}
+
+fun box(): String {
+    val g = Greeter()
+    g.publicGreet()
+    g.internalGreet()
+    if (publicHits != 1) return "FAIL: publicHits=$publicHits (expected 1)"
+    if (internalHits != 1) return "FAIL: internalHits=$internalHits (expected 1)"
+    return "OK"
+}


### PR DESCRIPTION
## Summary

Phase 3.5.7 of the v1 roadmap, stacked on #27 (`feat/v1-phase3.5.6-test-coverage`).

Adds four box fixtures that exercise the matching dimensions from Phase 3.4 beyond the `` `@ClassName` `` / `` `@MethodName` `` patterns already covered:

| Fixture | Verifies |
|---|---|
| `visibilityMatching.kt` | `` `@Visibility(PUBLIC)` `` and `` `@Visibility(INTERNAL)` `` each match only same-visibility targets |
| `modifiersMatching.kt` | `` `@Modifiers(INLINE)` `` matches only inline targets; an unconstrained advice matches both inline and non-inline |
| `annotatedMatching.kt` | `` `@Annotated(Loggable::class)` `` matches only functions carrying `@Loggable` |
| `packageMatching.kt` | `` `@Package("com.example.**")` `` matches a function declared in `com.example.app` |

Each test counts hits on side-effect counters across both matching and non-matching targets, so a regression in either direction fails `box()`.

## Test plan

- [x] `./gradlew :aspectk-compiler:test` — all 15 testcases green.