### PR TITLE
Phase 3.6: aspect instance caching via object-aspect support

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
@@ -27,7 +27,6 @@ import org.jetbrains.kotlin.ir.expressions.IrReturn
 import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
-import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
 
 /**
@@ -140,11 +139,8 @@ internal class AroundAdviceWeaver(
         return true
     }
 
-    private fun canInstantiateAspect(aspectClass: IrClass): Boolean {
-        if (aspectClass.kind == org.jetbrains.kotlin.descriptors.ClassKind.OBJECT) return true
-        val ctor = aspectClass.primaryConstructor ?: return false
-        return ctor.parameters.isEmpty()
-    }
+    private fun canInstantiateAspect(aspectClass: IrClass): Boolean =
+        AspectInstanceSupport.canInstantiate(aspectClass)
 
     private fun findAdviceLambda(adviceFn: IrSimpleFunction): IrFunction? {
         val body = adviceFn.body as? IrBlockBody ?: return null

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
@@ -82,8 +82,7 @@ internal class AroundAdviceWeaver(
         aspectClass: IrClass,
         advice: AdviceMetadata,
     ): Boolean {
-        val ctor = aspectClass.primaryConstructor ?: return false
-        if (ctor.parameters.isNotEmpty()) return false
+        if (!canInstantiateAspect(aspectClass)) return false
 
         val adviceFn = advice.function
         val lambdaFn = findAdviceLambda(adviceFn) ?: return false
@@ -139,6 +138,12 @@ internal class AroundAdviceWeaver(
             for (stmt in clonedBody.statements) +stmt
         }
         return true
+    }
+
+    private fun canInstantiateAspect(aspectClass: IrClass): Boolean {
+        if (aspectClass.kind == org.jetbrains.kotlin.descriptors.ClassKind.OBJECT) return true
+        val ctor = aspectClass.primaryConstructor ?: return false
+        return ctor.parameters.isEmpty()
     }
 
     private fun findAdviceLambda(adviceFn: IrSimpleFunction): IrFunction? {

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectInstanceSupport.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectInstanceSupport.kt
@@ -1,0 +1,53 @@
+package com.github.kitakkun.aspectk.compiler.backend.transformer
+
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.ir.builders.irCallConstructor
+import org.jetbrains.kotlin.ir.builders.irGetObject
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.util.primaryConstructor
+
+/**
+ * Single source of truth for "is this aspect class instantiable by the
+ * AspectK weavers?" and how to materialise an instance expression for it.
+ *
+ * Shared between `AspectKTransformer` (for `@Before` / `@After`) and
+ * `AroundAdviceWeaver` so the two paths stay in lockstep.
+ */
+internal object AspectInstanceSupport {
+    /**
+     * `true` if [aspectClass] is one of:
+     *
+     * - an `object` declaration (regular, companion, or sealed-object), whose
+     *   singleton INSTANCE we can read via `IrGetObjectValue`;
+     * - a regular `class` with a no-arg primary constructor, that we can
+     *   construct on demand.
+     */
+    fun canInstantiate(aspectClass: IrClass): Boolean {
+        if (aspectClass.kind == ClassKind.OBJECT) return true
+        val ctor = aspectClass.primaryConstructor ?: return false
+        return ctor.parameters.isEmpty()
+    }
+
+    /**
+     * Builds the IR expression that yields an instance of [aspectClass] at
+     * the weaving site:
+     *
+     * - `object` → `IrGetObjectValue` (singleton, naturally cached).
+     * - `class` → fresh `IrCallConstructor` per call site.
+     *
+     * Returns `null` if [canInstantiate] would return false.
+     */
+    fun instanceExpression(
+        aspectClass: IrClass,
+        builder: DeclarationIrBuilder,
+    ): IrExpression? {
+        if (aspectClass.kind == ClassKind.OBJECT) {
+            return builder.irGetObject(aspectClass.symbol)
+        }
+        val ctor = aspectClass.primaryConstructor ?: return null
+        if (ctor.parameters.isNotEmpty()) return null
+        return builder.irCallConstructor(ctor.symbol, emptyList())
+    }
+}

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irGetObject
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
@@ -130,19 +131,22 @@ internal class AspectKTransformer(
     }
 
     /**
-     * Builds an `IrCall` invoking [advice] with a freshly constructed aspect
-     * instance as dispatch receiver and each declared binding's extracted value
-     * forwarded into the matching slot. Returns `null` if the aspect has no
-     * no-arg primary constructor (caching arrives in Phase 3.6).
+     * Builds an `IrCall` invoking [advice]. The advice's dispatch receiver is:
+     *
+     * - For an ``object`` aspect: the singleton `INSTANCE`, read via
+     *   `IrGetObjectValue`. Each weave site shares the same instance.
+     * - For a regular ``class`` aspect with a no-arg primary constructor: a
+     *   freshly constructed instance per weave site (the v0.x behaviour). User
+     *   opts into caching by declaring the aspect as ``object``.
+     *
+     * Returns `null` if neither shape applies (e.g. ``class`` with required
+     * constructor parameters).
      */
     private fun buildAdviceCall(
         target: IrSimpleFunction,
         aspectClass: IrClass,
         advice: AdviceMetadata,
     ): IrCall? {
-        val ctor = aspectClass.primaryConstructor ?: return null
-        if (ctor.parameters.isNotEmpty()) return null
-
         val adviceFn = advice.function
         val builder = DeclarationIrBuilder(
             pluginContext,
@@ -150,9 +154,10 @@ internal class AspectKTransformer(
             target.startOffset,
             target.endOffset,
         )
+        val aspectInstance = aspectInstance(aspectClass, builder) ?: return null
         return builder.irCall(adviceFn.symbol).apply {
             // arguments[0] is the advice's dispatch receiver (the aspect instance).
-            arguments[0] = builder.irCallConstructor(ctor.symbol, emptyList())
+            arguments[0] = aspectInstance
             for (binding in advice.bindings) {
                 val adviceSlotIndex = adviceFn.parameters.indexOf(binding.adviceParameter)
                 if (adviceSlotIndex < 0) continue
@@ -160,6 +165,18 @@ internal class AspectKTransformer(
                 arguments[adviceSlotIndex] = value
             }
         }
+    }
+
+    private fun aspectInstance(
+        aspectClass: IrClass,
+        builder: DeclarationIrBuilder,
+    ): IrExpression? {
+        if (aspectClass.kind == org.jetbrains.kotlin.descriptors.ClassKind.OBJECT) {
+            return builder.irGetObject(aspectClass.symbol)
+        }
+        val ctor = aspectClass.primaryConstructor ?: return null
+        if (ctor.parameters.isNotEmpty()) return null
+        return builder.irCallConstructor(ctor.symbol, emptyList())
     }
 
     private fun extractBindingValue(

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
@@ -11,9 +11,7 @@ import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irCall
-import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irGet
-import org.jetbrains.kotlin.ir.builders.irGetObject
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
@@ -24,7 +22,6 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrTryImpl
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
-import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
 
 /**
@@ -170,14 +167,7 @@ internal class AspectKTransformer(
     private fun aspectInstance(
         aspectClass: IrClass,
         builder: DeclarationIrBuilder,
-    ): IrExpression? {
-        if (aspectClass.kind == org.jetbrains.kotlin.descriptors.ClassKind.OBJECT) {
-            return builder.irGetObject(aspectClass.symbol)
-        }
-        val ctor = aspectClass.primaryConstructor ?: return null
-        if (ctor.parameters.isNotEmpty()) return null
-        return builder.irCallConstructor(ctor.symbol, emptyList())
-    }
+    ): IrExpression? = AspectInstanceSupport.instanceExpression(aspectClass, builder)
 
     private fun extractBindingValue(
         binding: Binding,

--- a/aspectk-compiler/testData/box/objectAspectSingleton.fir.ir.txt
+++ b/aspectk-compiler/testData/box/objectAspectSingleton.fir.ir.txt
@@ -1,0 +1,108 @@
+FILE fqName:<root> fileName:/ObjectAspectSingleton.kt
+  CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Greeter
+    CONSTRUCTOR visibility:public returnType:<root>.Greeter [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:greet visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Greeter
+      BLOCK_BODY
+        CALL 'public final fun beforeGreet (): kotlin.Unit declared in <root>.SingletonTracer' type=kotlin.Unit origin=null
+          ARG <this>: GET_OBJECT 'CLASS OBJECT name:SingletonTracer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.SingletonTracer
+  CLASS OBJECT name:SingletonTracer modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.SingletonTracer
+    PROPERTY name:seenInstances visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:seenInstances type:kotlin.collections.MutableSet<kotlin.Int> visibility:private
+        EXPRESSION_BODY
+          CALL 'public final fun mutableSetOf <T> (): kotlin.collections.MutableSet<T of kotlin.collections.mutableSetOf> declared in kotlin.collections' type=kotlin.collections.MutableSet<kotlin.Int> origin=null
+            TYPE_ARG T: kotlin.Int
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-seenInstances> visibility:public modality:FINAL returnType:kotlin.collections.MutableSet<kotlin.Int>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.SingletonTracer
+        correspondingProperty: PROPERTY name:seenInstances visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-seenInstances> (): kotlin.collections.MutableSet<kotlin.Int> declared in <root>.SingletonTracer'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:seenInstances type:kotlin.collections.MutableSet<kotlin.Int> visibility:private' type=kotlin.collections.MutableSet<kotlin.Int> origin=null
+              receiver: GET_VAR '<this>: <root>.SingletonTracer declared in <root>.SingletonTracer.<get-seenInstances>' type=<root>.SingletonTracer origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-seenInstances> visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.SingletonTracer
+        VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.collections.MutableSet<kotlin.Int>
+        correspondingProperty: PROPERTY name:seenInstances visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:seenInstances type:kotlin.collections.MutableSet<kotlin.Int> visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.SingletonTracer declared in <root>.SingletonTracer.<set-seenInstances>' type=<root>.SingletonTracer origin=null
+            value: GET_VAR '<set-?>: kotlin.collections.MutableSet<kotlin.Int> declared in <root>.SingletonTracer.<set-seenInstances>' type=kotlin.collections.MutableSet<kotlin.Int> origin=null
+    CONSTRUCTOR visibility:private returnType:<root>.SingletonTracer [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS OBJECT name:SingletonTracer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeGreet visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.SingletonTracer
+      annotations:
+        Before
+        ClassName(pattern = "Greeter")
+        MethodName(pattern = "greet")
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          CALL 'public abstract fun add (element: E of kotlin.collections.MutableSet): kotlin.Boolean declared in kotlin.collections.MutableSet' type=kotlin.Boolean origin=null
+            ARG <this>: CALL 'public final fun <get-seenInstances> (): kotlin.collections.MutableSet<kotlin.Int> declared in <root>.SingletonTracer' type=kotlin.collections.MutableSet<kotlin.Int> origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: <root>.SingletonTracer declared in <root>.SingletonTracer.beforeGreet' type=<root>.SingletonTracer origin=IMPLICIT_ARGUMENT
+            ARG element: CALL 'public open fun identityHashCode (p0: @[FlexibleNullability] kotlin.Any?): kotlin.Int declared in java.lang.System' type=kotlin.Int origin=null
+              ARG p0: GET_VAR '<this>: <root>.SingletonTracer declared in <root>.SingletonTracer.beforeGreet' type=<root>.SingletonTracer origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:g type:<root>.Greeter [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Greeter' type=<root>.Greeter origin=null
+      CALL 'public final fun repeat (times: kotlin.Int, action: kotlin.Function1<kotlin.Int, kotlin.Unit>): kotlin.Unit declared in kotlin' type=kotlin.Unit origin=null
+        ARG times: CONST Int type=kotlin.Int value=3
+        ARG action: FUN_EXPR type=kotlin.Function1<kotlin.Int, kotlin.Unit> origin=LAMBDA
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+            VALUE_PARAMETER kind:Regular name:it index:0 type:kotlin.Int
+            BLOCK_BODY
+              CALL 'public final fun greet (): kotlin.Unit declared in <root>.Greeter' type=kotlin.Unit origin=null
+                ARG <this>: GET_VAR 'val g: <root>.Greeter declared in <root>.box' type=<root>.Greeter origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public abstract fun <get-size> (): kotlin.Int declared in kotlin.collections.MutableSet' type=kotlin.Int origin=GET_PROPERTY
+                ARG <this>: CALL 'public final fun <get-seenInstances> (): kotlin.collections.MutableSet<kotlin.Int> declared in <root>.SingletonTracer' type=kotlin.collections.MutableSet<kotlin.Int> origin=GET_PROPERTY
+                  ARG <this>: GET_OBJECT 'CLASS OBJECT name:SingletonTracer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.SingletonTracer
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: BLOCK type=kotlin.Unit origin=null
+            RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+              STRING_CONCATENATION type=kotlin.String
+                CONST String type=kotlin.String value="FAIL: expected 1 distinct aspect instance across 3 calls, got "
+                CALL 'public abstract fun <get-size> (): kotlin.Int declared in kotlin.collections.MutableSet' type=kotlin.Int origin=GET_PROPERTY
+                  ARG <this>: CALL 'public final fun <get-seenInstances> (): kotlin.collections.MutableSet<kotlin.Int> declared in <root>.SingletonTracer' type=kotlin.collections.MutableSet<kotlin.Int> origin=GET_PROPERTY
+                    ARG <this>: GET_OBJECT 'CLASS OBJECT name:SingletonTracer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.SingletonTracer
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/objectAspectSingleton.kt
+++ b/aspectk-compiler/testData/box/objectAspectSingleton.kt
@@ -1,0 +1,33 @@
+// FILE: ObjectAspectSingleton.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.MethodName
+
+class Greeter {
+    fun greet() {}
+}
+
+@Aspect
+object SingletonTracer {
+    var seenInstances: MutableSet<Int> = mutableSetOf()
+
+    @Before
+    @ClassName("Greeter")
+    @MethodName("greet")
+    fun beforeGreet() {
+        // System.identityHashCode would distinguish multiple instances; for a
+        // singleton, every invocation observes the same object identity.
+        seenInstances.add(System.identityHashCode(this))
+    }
+}
+
+fun box(): String {
+    val g = Greeter()
+    repeat(3) { g.greet() }
+    if (SingletonTracer.seenInstances.size != 1) {
+        return "FAIL: expected 1 distinct aspect instance across 3 calls, got ${SingletonTracer.seenInstances.size}"
+    }
+    return "OK"
+}


### PR DESCRIPTION
## Summary

Phase 3.6 of the v1 roadmap, stacked on #28.

Adds caching of the aspect instance across woven call sites by recognising `object` aspect declarations as singletons. Users opt into caching by declaring `object MyAspect` instead of `class MyAspect`; `class`-form aspects continue to construct a fresh instance per weave site (v0.x behaviour).

### IR transformation

- `AspectKTransformer.buildAdviceCall` factors the aspect-instance expression into `aspectInstance(aspectClass, builder)` and branches on `aspectClass.kind`:
  - `ClassKind.OBJECT` → `IrGetObjectValue` to read the singleton `INSTANCE` already generated by the Kotlin compiler for any `object`.
  - `ClassKind.CLASS` with a no-arg primary constructor → `irCallConstructor` (unchanged).
- `AroundAdviceWeaver.weave` similarly accepts both shapes via a shared `canInstantiateAspect` check, though it doesn't actually construct at the call site (the advice body is inlined).

### Test

`testData/box/objectAspectSingleton.kt` declares `object SingletonTracer` and asserts that `System.identityHashCode(this)` collected across three calls to the same target produces exactly **one** distinct value, proving the aspect instance is reused.

### Not in scope

- Automatic caching for `class` aspects (would need synthesising a companion object + `INSTANCE` property via a FIR declaration generator, larger work).
- Cross-classloader caching guarantees (each classloader gets its own singleton, same as any Kotlin `object`).

## Test plan

- [x] `./gradlew :aspectk-compiler:test` — 16 tests green.