### PR TITLE
Phase 3.x: @ValueParameters / @ContextParameters catch-all bindings

### DIFF
--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ContextParameters.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ContextParameters.kt
@@ -1,0 +1,12 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Catch-all binding for the matched target call's **context parameters**:
+ * every context argument is collected into a `List<Any?>` in declaration
+ * order and passed to the bound parameter.
+ *
+ * Complementary to [ContextParameter] (singular).
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.BINARY)
+annotation class ContextParameters

--- a/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ValueParameters.kt
+++ b/aspectk-annotations/src/commonMain/kotlin/com/github/kitakkun/aspectk/annotations/ValueParameters.kt
@@ -1,0 +1,22 @@
+package com.github.kitakkun.aspectk.annotations
+
+/**
+ * Catch-all binding for the matched target call's **value parameters**: every
+ * value argument is collected into a `List<Any?>` in declaration order and
+ * passed to the bound parameter.
+ *
+ * ```kotlin
+ * @Before @MethodName("*")
+ * fun logAll(@ValueParameters args: List<Any?>) {
+ *     println("called with $args")
+ * }
+ * ```
+ *
+ * Complementary to [ValueParameter] (singular), which binds one specific slot
+ * by index or name. Use [ValueParameters] when you don't know or don't care
+ * which arguments the target declares — typical for generic logging or
+ * auditing aspects.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.BINARY)
+annotation class ValueParameters

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKAnnotations.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKAnnotations.kt
@@ -34,11 +34,15 @@ object AspectKAnnotations {
     val EXTENSION_RECEIVER_CLASS_ID = classId(PKG, "ExtensionReceiver")
     val CONTEXT_PARAMETER_CLASS_ID = classId(PKG, "ContextParameter")
     val VALUE_PARAMETER_CLASS_ID = classId(PKG, "ValueParameter")
+    val VALUE_PARAMETERS_CLASS_ID = classId(PKG, "ValueParameters")
+    val CONTEXT_PARAMETERS_CLASS_ID = classId(PKG, "ContextParameters")
 
     val DISPATCH_RECEIVER_FQ_NAME = DISPATCH_RECEIVER_CLASS_ID.asSingleFqName()
     val EXTENSION_RECEIVER_FQ_NAME = EXTENSION_RECEIVER_CLASS_ID.asSingleFqName()
     val CONTEXT_PARAMETER_FQ_NAME = CONTEXT_PARAMETER_CLASS_ID.asSingleFqName()
     val VALUE_PARAMETER_FQ_NAME = VALUE_PARAMETER_CLASS_ID.asSingleFqName()
+    val VALUE_PARAMETERS_FQ_NAME = VALUE_PARAMETERS_CLASS_ID.asSingleFqName()
+    val CONTEXT_PARAMETERS_FQ_NAME = CONTEXT_PARAMETERS_CLASS_ID.asSingleFqName()
 
     val POINTCUT_FQ_NAME = POINTCUT_CLASS_ID.asSingleFqName()
 

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectAnalyzer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectAnalyzer.kt
@@ -137,6 +137,12 @@ internal class AspectAnalyzer {
         param.getAnnotation(AspectKAnnotations.EXTENSION_RECEIVER_FQ_NAME)?.let {
             return Binding.ExtensionReceiver(param)
         }
+        param.getAnnotation(AspectKAnnotations.VALUE_PARAMETERS_FQ_NAME)?.let {
+            return Binding.ValueParameters(param)
+        }
+        param.getAnnotation(AspectKAnnotations.CONTEXT_PARAMETERS_FQ_NAME)?.let {
+            return Binding.ContextParameters(param)
+        }
         param.getAnnotation(AspectKAnnotations.CONTEXT_PARAMETER_FQ_NAME)?.let { ann ->
             val (index, name) = readIndexNameArgs(ann)
             return Binding.ContextParameter(param, index, name)

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectMetadata.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectMetadata.kt
@@ -60,4 +60,10 @@ internal sealed interface Binding {
         val index: Int?,
         val name: String?,
     ) : Binding
+
+    /** Catch-all binding capturing every value parameter as a `List<Any?>`. */
+    data class ValueParameters(override val adviceParameter: IrValueParameter) : Binding
+
+    /** Catch-all binding capturing every context parameter as a `List<Any?>`. */
+    data class ContextParameters(override val adviceParameter: IrValueParameter) : Binding
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/matching/PointcutMatcher.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/matching/PointcutMatcher.kt
@@ -178,6 +178,8 @@ internal object PointcutMatcher {
             val ok = when (binding) {
                 is Binding.DispatchReceiver -> targetHasDispatch
                 is Binding.ExtensionReceiver -> targetHasExtension
+                is Binding.ValueParameters -> true // catch-all, accepts any (including zero) value parameters
+                is Binding.ContextParameters -> true // catch-all
                 is Binding.ValueParameter -> when {
                     binding.index != null -> binding.index in targetValueParams.indices
                     binding.name != null -> targetValueParams.any { it.name.asString() == binding.name }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
@@ -3,6 +3,7 @@ package com.github.kitakkun.aspectk.compiler.backend.transformer
 import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
 import com.github.kitakkun.aspectk.compiler.backend.analyzer.AdviceMetadata
 import com.github.kitakkun.aspectk.compiler.backend.analyzer.Binding
+import com.github.kitakkun.aspectk.compiler.fir.checker.AspectKErrors
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.IrElement
@@ -97,7 +98,7 @@ internal class AroundAdviceWeaver(
             pluginContext.diagnosticReporter
                 .at(advice.function)
                 .report(
-                    com.github.kitakkun.aspectk.compiler.fir.checker.AspectKErrors.AROUND_UNSUPPORTED_BINDING,
+                    AspectKErrors.AROUND_UNSUPPORTED_BINDING,
                     "$annotationName binding is not yet supported by the @Around weaver",
                 )
             return false

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
@@ -85,7 +85,21 @@ internal class AroundAdviceWeaver(
         // Catch-all bindings (`@ValueParameters` / `@ContextParameters`) require
         // synthesising a `listOf<Any?>(…)` at the call site; integrating that
         // with the around weaver's local-var substitution path isn't done yet.
-        if (advice.bindings.any { it is Binding.ValueParameters || it is Binding.ContextParameters }) {
+        val catchAll = advice.bindings.firstOrNull {
+            it is Binding.ValueParameters || it is Binding.ContextParameters
+        }
+        if (catchAll != null) {
+            val annotationName = when (catchAll) {
+                is Binding.ValueParameters -> "@ValueParameters"
+                is Binding.ContextParameters -> "@ContextParameters"
+                else -> "@?"
+            }
+            pluginContext.diagnosticReporter
+                .at(advice.function)
+                .report(
+                    com.github.kitakkun.aspectk.compiler.fir.checker.AspectKErrors.AROUND_UNSUPPORTED_BINDING,
+                    "$annotationName binding is not yet supported by the @Around weaver",
+                )
             return false
         }
 

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
@@ -82,6 +82,12 @@ internal class AroundAdviceWeaver(
         advice: AdviceMetadata,
     ): Boolean {
         if (!canInstantiateAspect(aspectClass)) return false
+        // Catch-all bindings (`@ValueParameters` / `@ContextParameters`) require
+        // synthesising a `listOf<Any?>(…)` at the call site; integrating that
+        // with the around weaver's local-var substitution path isn't done yet.
+        if (advice.bindings.any { it is Binding.ValueParameters || it is Binding.ContextParameters }) {
+            return false
+        }
 
         val adviceFn = advice.function
         val lambdaFn = findAdviceLambda(adviceFn) ?: return false
@@ -185,6 +191,11 @@ internal class AroundAdviceWeaver(
                     else -> null
                 }
             }
+            // Catch-all bindings don't map to a single target slot. They are
+            // intentionally not supported inside `@Around` advice in this PR —
+            // returning null leaves them out of the substitution map, and the
+            // weaver bails for any advice that declares one.
+            is Binding.ValueParameters, is Binding.ContextParameters -> null
         }
 }
 

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
@@ -16,14 +16,18 @@ import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
-import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrTryImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrVarargImpl
+import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
 
 /**
  * Phase 3.2 advice applier.
@@ -208,17 +212,14 @@ internal class AspectKTransformer(
     ): IrExpression? {
         val anyNType = pluginContext.irBuiltIns.anyNType
         val listOfSymbol = pluginContext.referenceFunctions(
-            org.jetbrains.kotlin.name.CallableId(
-                org.jetbrains.kotlin.name.FqName("kotlin.collections"),
-                org.jetbrains.kotlin.name.Name.identifier("listOf"),
-            ),
+            CallableId(FqName("kotlin.collections"), Name.identifier("listOf")),
         ).firstOrNull { fn ->
             val regular = fn.owner.parameters.filter { it.kind == IrParameterKind.Regular }
             regular.size == 1 && regular[0].varargElementType != null
         } ?: return null
 
         val arrayType = pluginContext.irBuiltIns.arrayClass.typeWith(anyNType)
-        val vararg = org.jetbrains.kotlin.ir.expressions.impl.IrVarargImpl(
+        val vararg = IrVarargImpl(
             startOffset = builder.startOffset,
             endOffset = builder.endOffset,
             type = arrayType,

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -174,13 +175,60 @@ internal class AspectKTransformer(
         target: IrSimpleFunction,
         builder: DeclarationIrBuilder,
     ): IrExpression? {
-        val sourceParam = when (binding) {
-            is Binding.DispatchReceiver -> target.parameters.firstOrNull { it.kind == IrParameterKind.DispatchReceiver }
-            is Binding.ExtensionReceiver -> target.parameters.firstOrNull { it.kind == IrParameterKind.ExtensionReceiver }
+        return when (binding) {
+            is Binding.DispatchReceiver -> target.parameters
+                .firstOrNull { it.kind == IrParameterKind.DispatchReceiver }
+                ?.let(builder::irGet)
+            is Binding.ExtensionReceiver -> target.parameters
+                .firstOrNull { it.kind == IrParameterKind.ExtensionReceiver }
+                ?.let(builder::irGet)
             is Binding.ValueParameter -> findRegular(target, binding.index, binding.name)
+                ?.let(builder::irGet)
             is Binding.ContextParameter -> findContext(target, binding.index, binding.name)
+                ?.let(builder::irGet)
+            is Binding.ValueParameters -> buildAnyNullableList(
+                target.parameters.filter { it.kind == IrParameterKind.Regular },
+                builder,
+            )
+            is Binding.ContextParameters -> buildAnyNullableList(
+                target.parameters.filter { it.kind == IrParameterKind.Context },
+                builder,
+            )
+        }
+    }
+
+    /**
+     * Builds a `listOf<Any?>(p0, p1, …)` expression that materialises [params]
+     * (as `IrGetValue` reads) into a `List<Any?>` at the woven call site.
+     * Returns `null` if `kotlin.collections.listOf` can't be resolved.
+     */
+    private fun buildAnyNullableList(
+        params: List<IrValueParameter>,
+        builder: DeclarationIrBuilder,
+    ): IrExpression? {
+        val anyNType = pluginContext.irBuiltIns.anyNType
+        val listOfSymbol = pluginContext.referenceFunctions(
+            org.jetbrains.kotlin.name.CallableId(
+                org.jetbrains.kotlin.name.FqName("kotlin.collections"),
+                org.jetbrains.kotlin.name.Name.identifier("listOf"),
+            ),
+        ).firstOrNull { fn ->
+            val regular = fn.owner.parameters.filter { it.kind == IrParameterKind.Regular }
+            regular.size == 1 && regular[0].varargElementType != null
         } ?: return null
-        return builder.irGet(sourceParam)
+
+        val arrayType = pluginContext.irBuiltIns.arrayClass.typeWith(anyNType)
+        val vararg = org.jetbrains.kotlin.ir.expressions.impl.IrVarargImpl(
+            startOffset = builder.startOffset,
+            endOffset = builder.endOffset,
+            type = arrayType,
+            varargElementType = anyNType,
+            elements = params.map { builder.irGet(it) },
+        )
+        return builder.irCall(listOfSymbol).apply {
+            typeArguments[0] = anyNType
+            arguments[0] = vararg
+        }
     }
 
     private fun findRegular(

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
@@ -32,6 +32,14 @@ object AspectKErrors : KtDiagnosticsContainer() {
      */
     val WOVEN_CALL_SITE by warning1<KtElement, String>()
 
+    /**
+     * An `@Around` advice declares a binding shape the around weaver doesn't
+     * (yet) support — typically `@ValueParameters` / `@ContextParameters`.
+     * The advice silently doesn't weave; this warning surfaces that so the
+     * user isn't left wondering why their `@Around` stopped intercepting.
+     */
+    val AROUND_UNSUPPORTED_BINDING by warning1<KtElement, String>()
+
     override fun getRendererFactory(): BaseDiagnosticRendererFactory = AspectKDefaultMessages
 }
 
@@ -63,6 +71,11 @@ private object AspectKDefaultMessages : BaseDiagnosticRendererFactory() {
         map.put(
             AspectKErrors.WOVEN_CALL_SITE,
             "intercepted by {0}",
+            CommonRenderers.STRING,
+        )
+        map.put(
+            AspectKErrors.AROUND_UNSUPPORTED_BINDING,
+            "@Around advice not woven: {0}",
             CommonRenderers.STRING,
         )
     }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/BindingAnnotationChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/BindingAnnotationChecker.kt
@@ -10,19 +10,35 @@ import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
 
 /**
- * Validates the indexed-or-named binding annotations on advice value parameters.
+ * Validates binding annotations on advice value parameters.
  *
- * `@ValueParameter` and `@ContextParameter` each declare both `index: Int = -1`
- * and `name: String = ""`. Exactly one must be set: `index >= 0` xor
- * `name.isNotEmpty()`. The default-both and both-set forms are rejected here
- * so the user gets a clear diagnostic rather than a silently-mismatching
- * binding at IR time.
+ * Two distinct checks run per parameter:
  *
- * `@DispatchReceiver` and `@ExtensionReceiver` take no arguments and are not
- * checked here.
+ * 1. **Multiple binding annotations on the same parameter** — at most one
+ *    of `@DispatchReceiver` / `@ExtensionReceiver` / `@ContextParameter` /
+ *    `@ValueParameter` / `@ContextParameters` / `@ValueParameters` may be
+ *    present. More than one is ambiguous and would otherwise lead the
+ *    analyzer to silently pick the first one in lookup order.
+ * 2. **Index/name xor** — `@ValueParameter` and `@ContextParameter` carry
+ *    `index: Int = -1` and `name: String = ""`. Exactly one must be set;
+ *    the default-both and both-set forms are rejected so the user gets a
+ *    clear diagnostic rather than a silently-mismatching binding at IR time.
+ *
+ * `@DispatchReceiver`, `@ExtensionReceiver`, `@ValueParameters`, and
+ * `@ContextParameters` take no arguments and are not subject to the second
+ * check.
  */
 object BindingAnnotationChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
-    private val annotationsToValidate = listOf(
+    private val allBindingAnnotations = listOf(
+        AspectKAnnotations.DISPATCH_RECEIVER_CLASS_ID to "DispatchReceiver",
+        AspectKAnnotations.EXTENSION_RECEIVER_CLASS_ID to "ExtensionReceiver",
+        AspectKAnnotations.CONTEXT_PARAMETER_CLASS_ID to "ContextParameter",
+        AspectKAnnotations.VALUE_PARAMETER_CLASS_ID to "ValueParameter",
+        AspectKAnnotations.CONTEXT_PARAMETERS_CLASS_ID to "ContextParameters",
+        AspectKAnnotations.VALUE_PARAMETERS_CLASS_ID to "ValueParameters",
+    )
+
+    private val indexOrNameAnnotations = listOf(
         AspectKAnnotations.VALUE_PARAMETER_CLASS_ID to "ValueParameter",
         AspectKAnnotations.CONTEXT_PARAMETER_CLASS_ID to "ContextParameter",
     )
@@ -30,11 +46,23 @@ object BindingAnnotationChecker : FirSimpleFunctionChecker(MppCheckerKind.Common
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         for (param in declaration.valueParameters) {
-            for ((classId, displayName) in annotationsToValidate) {
+            val present = allBindingAnnotations.mapNotNull { (classId, displayName) ->
+                param.getAnnotationByClassId(classId, context.session)?.let { it to displayName }
+            }
+            if (present.size >= 2) {
+                val firstAnnotation = present[0].first
+                val src = firstAnnotation.source ?: param.source ?: continue
+                val names = present.joinToString(" / ") { "@${it.second}" }
+                reporter.reportOn(
+                    src,
+                    AspectKErrors.INVALID_BINDING_ANNOTATION,
+                    present[0].second,
+                    "at most one binding annotation per parameter (found $names)",
+                )
+                continue
+            }
+            for ((classId, displayName) in indexOrNameAnnotations) {
                 val annotation = param.getAnnotationByClassId(classId, context.session) ?: continue
-                // Presence-based check: the user must pass exactly one of `index` / `name`.
-                // Default values (`index = -1`, `name = ""`) leave the corresponding key
-                // out of the resolved argument mapping.
                 val hasIndex = AspectKAnnotations.INDEX in annotation.argumentMapping.mapping
                 val hasName = AspectKAnnotations.NAME in annotation.argumentMapping.mapping
                 val message = when {

--- a/aspectk-compiler/testData/box/valueParametersCatchAll.fir.ir.txt
+++ b/aspectk-compiler/testData/box/valueParametersCatchAll.fir.ir.txt
@@ -1,0 +1,115 @@
+FILE fqName:<root> fileName:/ValueParametersCatchAll.kt
+  PROPERTY name:seen visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:seen type:kotlin.collections.List<kotlin.Any?> visibility:private [static]
+      EXPRESSION_BODY
+        CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Any?> origin=null
+          TYPE_ARG T: kotlin.Any?
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-seen> visibility:public modality:FINAL returnType:kotlin.collections.List<kotlin.Any?>
+      correspondingProperty: PROPERTY name:seen visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-seen> (): kotlin.collections.List<kotlin.Any?> declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:seen type:kotlin.collections.List<kotlin.Any?> visibility:private [static]' type=kotlin.collections.List<kotlin.Any?> origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<set-seen> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.collections.List<kotlin.Any?>
+      correspondingProperty: PROPERTY name:seen visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:seen type:kotlin.collections.List<kotlin.Any?> visibility:private [static]' type=kotlin.Unit origin=null
+          value: GET_VAR '<set-?>: kotlin.collections.List<kotlin.Any?> declared in <root>.<set-seen>' type=kotlin.collections.List<kotlin.Any?> origin=null
+  CLASS CLASS name:Auditor modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Aspect
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Auditor
+    CONSTRUCTOR visibility:public returnType:<root>.Auditor [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Auditor modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:beforeProcess visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Auditor
+      VALUE_PARAMETER kind:Regular name:args index:1 type:kotlin.collections.List<kotlin.Any?>
+        annotations:
+          ValueParameters
+      annotations:
+        Before
+        ClassName(pattern = "Service")
+        MethodName(pattern = "process")
+      BLOCK_BODY
+        CALL 'public final fun <set-seen> (<set-?>: kotlin.collections.List<kotlin.Any?>): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+          ARG <set-?>: GET_VAR 'args: kotlin.collections.List<kotlin.Any?> declared in <root>.Auditor.beforeProcess' type=kotlin.collections.List<kotlin.Any?> origin=null
+  CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Service
+    CONSTRUCTOR visibility:public returnType:<root>.Service [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:process visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Service
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:count index:2 type:kotlin.Int
+      VALUE_PARAMETER kind:Regular name:flag index:3 type:kotlin.Boolean
+      BLOCK_BODY
+        CALL 'public final fun beforeProcess (args: kotlin.collections.List<kotlin.Any?>): kotlin.Unit declared in <root>.Auditor' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Auditor' type=<root>.Auditor origin=null
+          ARG args: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<T of kotlin.collections.listOf> origin=null
+            TYPE_ARG T: kotlin.Any?
+            ARG elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
+              GET_VAR 'name: kotlin.String declared in <root>.Service.process' type=kotlin.String origin=null
+              GET_VAR 'count: kotlin.Int declared in <root>.Service.process' type=kotlin.Int origin=null
+              GET_VAR 'flag: kotlin.Boolean declared in <root>.Service.process' type=kotlin.Boolean origin=null
+        RETURN type=kotlin.Nothing from='public final fun process (name: kotlin.String, count: kotlin.Int, flag: kotlin.Boolean): kotlin.String declared in <root>.Service'
+          STRING_CONCATENATION type=kotlin.String
+            GET_VAR 'name: kotlin.String declared in <root>.Service.process' type=kotlin.String origin=null
+            CONST String type=kotlin.String value=":"
+            GET_VAR 'count: kotlin.Int declared in <root>.Service.process' type=kotlin.Int origin=null
+            CONST String type=kotlin.String value=":"
+            GET_VAR 'flag: kotlin.Boolean declared in <root>.Service.process' type=kotlin.Boolean origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun process (name: kotlin.String, count: kotlin.Int, flag: kotlin.Boolean): kotlin.String declared in <root>.Service' type=kotlin.String origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Service' type=<root>.Service origin=null
+          ARG name: CONST String type=kotlin.String value="alice"
+          ARG count: CONST Int type=kotlin.Int value=42
+          ARG flag: CONST Boolean type=kotlin.Boolean value=true
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-seen> (): kotlin.collections.List<kotlin.Any?> declared in <root>' type=kotlin.collections.List<kotlin.Any?> origin=GET_PROPERTY
+              ARG arg1: CALL 'public final fun listOf <T> (vararg elements: T of kotlin.collections.listOf): kotlin.collections.List<T of kotlin.collections.listOf> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Any?> origin=null
+                TYPE_ARG T: kotlin.Any?
+                ARG elements: VARARG type=kotlin.Array<out kotlin.Any?> varargElementType=kotlin.Any?
+                  CONST String type=kotlin.String value="alice"
+                  CONST Int type=kotlin.Int value=42
+                  CONST Boolean type=kotlin.Boolean value=true
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: seen="
+              CALL 'public final fun <get-seen> (): kotlin.collections.List<kotlin.Any?> declared in <root>' type=kotlin.collections.List<kotlin.Any?> origin=GET_PROPERTY
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/aspectk-compiler/testData/box/valueParametersCatchAll.kt
+++ b/aspectk-compiler/testData/box/valueParametersCatchAll.kt
@@ -1,0 +1,29 @@
+// FILE: ValueParametersCatchAll.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.ValueParameters
+
+var seen: List<Any?> = emptyList()
+
+class Service {
+    fun process(name: String, count: Int, flag: Boolean): String = "$name:$count:$flag"
+}
+
+@Aspect
+class Auditor {
+    @Before
+    @ClassName("Service")
+    @MethodName("process")
+    fun beforeProcess(@ValueParameters args: List<Any?>) {
+        seen = args
+    }
+}
+
+fun box(): String {
+    Service().process("alice", 42, true)
+    if (seen != listOf<Any?>("alice", 42, true)) return "FAIL: seen=$seen"
+    return "OK"
+}


### PR DESCRIPTION
## Summary

Phase 3.x of the v1 roadmap, stacked on #29 (`feat/v1-phase3.6-aspect-caching`).

Adds two new binding annotations that capture the matched target call's value or context parameters into a `List<Any?>`, complementing the indexed / named `@ValueParameter` / `@ContextParameter`. Useful for generic logging or auditing aspects that don't know (or don't care) about the target's specific parameter shape.

### New annotations

- `@ValueParameters` — `@Target(VALUE_PARAMETER)` marker; the bound advice parameter receives `List<Any?>` of all the target's value arguments in declaration order.
- `@ContextParameters` — same but for context parameters.

### Backend

- `AspectMetadata.Binding` gains `ValueParameters` and `ContextParameters` variants.
- `AspectAnalyzer` recognises the new annotations on advice parameters.
- `PointcutMatcher` accepts them as catch-all (presence-only) — they match a target with any (including zero) value / context parameters.
- `AspectKTransformer.extractBindingValue` builds a `listOf<Any?>(p0, p1, …)` IrCall at the woven call site, with each element materialised as `IrGetValue` on the target's matching parameter. `listOf` is resolved via `pluginContext.referenceFunctions(kotlin.collections.listOf)`, picking the vararg overload.

### @Around limitation

The around weaver's local-var substitution path doesn't yet handle catch-all bindings — a `@ValueParameters` / `@ContextParameters` binding inside an `@Around` advice causes the weaver to bail (no weaving) rather than miscompile. Documented as a follow-up.

### Test

`testData/box/valueParametersCatchAll.kt` — a `@Before` advice declares `@ValueParameters args: List<Any?>` and the `Auditor` aspect records the full args list. Calling `Service().process("alice", 42, true)` produces `seen == [alice, 42, true]`.

## Test plan

- [x] `./gradlew :aspectk-compiler:test` — 17 tests green.
