### PR TITLE
Phase 3.x: per-module weaving report (foundation for cross-module aggregator)

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCommandLineProcessor.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCommandLineProcessor.kt
@@ -22,6 +22,13 @@ class AspectKCommandLineProcessor : CommandLineProcessor {
             allowMultipleOccurrences = false,
             required = false,
         ),
+        CliOption(
+            optionName = "reportDir",
+            description = "Directory to write per-module weaving reports (matches-<module>.json)",
+            valueDescription = "<absolute-path>",
+            allowMultipleOccurrences = false,
+            required = false,
+        ),
     )
 
     override fun processOption(
@@ -31,6 +38,7 @@ class AspectKCommandLineProcessor : CommandLineProcessor {
     ) {
         when (option.optionName) {
             "enabled" -> configuration.put(AspectKCompilerConfigurationKey.ENABLED, value.toBoolean())
+            "reportDir" -> configuration.put(AspectKCompilerConfigurationKey.REPORT_DIR, value)
             else -> error("Unexpected config option ${option.optionName}")
         }
     }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCompilerConfigurationKey.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCompilerConfigurationKey.kt
@@ -5,4 +5,5 @@ import org.jetbrains.kotlin.config.CompilerConfigurationKey
 
 object AspectKCompilerConfigurationKey {
     val ENABLED = CompilerConfigurationKey<Boolean>(AspectKSubPluginOptionKey.ENABLED)
+    val REPORT_DIR = CompilerConfigurationKey<String>(AspectKSubPluginOptionKey.REPORT_DIR)
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCompilerPluginRegistrar.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCompilerPluginRegistrar.kt
@@ -21,7 +21,8 @@ class AspectKCompilerPluginRegistrar : CompilerPluginRegistrar() {
         val enabled = configuration[AspectKCompilerConfigurationKey.ENABLED] ?: false
         if (!enabled) return
 
+        val reportDir = configuration[AspectKCompilerConfigurationKey.REPORT_DIR]
         FirExtensionRegistrarAdapter.registerExtension(AspectKFirExtensionRegistrar())
-        IrGenerationExtension.registerExtension(AspectKIrGenerationExtension())
+        IrGenerationExtension.registerExtension(AspectKIrGenerationExtension(reportDir))
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrGenerationExtension.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrGenerationExtension.kt
@@ -1,18 +1,109 @@
 package com.github.kitakkun.aspectk.compiler.backend
 
+import com.github.kitakkun.aspectk.compiler.backend.analyzer.AdviceKind
+import com.github.kitakkun.aspectk.compiler.backend.analyzer.AdviceMetadata
 import com.github.kitakkun.aspectk.compiler.backend.analyzer.AspectAnalyzer
+import com.github.kitakkun.aspectk.compiler.backend.analyzer.AspectMetadata
 import com.github.kitakkun.aspectk.compiler.backend.transformer.AspectKTransformer
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.util.kotlinFqName
+import org.jetbrains.kotlin.ir.util.parentClassOrNull
+import java.io.File
 
-class AspectKIrGenerationExtension : IrGenerationExtension {
+class AspectKIrGenerationExtension(
+    private val reportDir: String?,
+) : IrGenerationExtension {
     override fun generate(
         moduleFragment: IrModuleFragment,
         pluginContext: IrPluginContext,
     ) {
         val aspects = AspectAnalyzer().analyze(moduleFragment)
         if (aspects.isEmpty()) return
-        moduleFragment.transform(AspectKTransformer(pluginContext, aspects), null)
+        val transformer = AspectKTransformer(pluginContext, aspects)
+        moduleFragment.transform(transformer, null)
+
+        reportDir?.let { dir ->
+            writeReport(File(dir), moduleFragment.name.asString(), aspects, transformer.matches)
+        }
+    }
+
+    private fun writeReport(
+        dir: File,
+        moduleName: String,
+        aspects: List<AspectMetadata>,
+        matches: Map<AdviceMetadata, List<IrSimpleFunction>>,
+    ) {
+        if (!dir.exists() && !dir.mkdirs()) return
+        val sanitized = moduleName.trim('<', '>').replace('/', '_')
+        val out = File(dir, "matches-$sanitized.json")
+        out.writeText(buildReportJson(moduleName, aspects, matches))
+    }
+
+    private fun buildReportJson(
+        moduleName: String,
+        aspects: List<AspectMetadata>,
+        matches: Map<AdviceMetadata, List<IrSimpleFunction>>,
+    ): String {
+        val sb = StringBuilder()
+        sb.append("{\n")
+        sb.append("  \"module\": ").append(jsonString(moduleName)).append(",\n")
+        sb.append("  \"advices\": [\n")
+        val adviceEntries = aspects.flatMap { aspect ->
+            aspect.advices.map { aspect to it }
+        }
+        adviceEntries.forEachIndexed { index, (aspect, advice) ->
+            val targets = matches[advice].orEmpty()
+            val aspectFq = aspect.aspectClass.kotlinFqName.asString()
+            sb.append("    {\n")
+            sb.append("      \"aspect\": ").append(jsonString(aspectFq)).append(",\n")
+            sb.append("      \"advice\": ").append(jsonString(advice.function.name.asString())).append(",\n")
+            sb.append("      \"kind\": ").append(jsonString(kindLabel(advice.kind))).append(",\n")
+            sb.append("      \"targets\": [")
+            if (targets.isEmpty()) {
+                sb.append("]\n")
+            } else {
+                sb.append('\n')
+                targets.forEachIndexed { tIndex, target ->
+                    val klass = target.parentClassOrNull?.kotlinFqName?.asString() ?: ""
+                    sb.append("        { \"class\": ").append(jsonString(klass))
+                    sb.append(", \"method\": ").append(jsonString(target.name.asString())).append(" }")
+                    if (tIndex != targets.lastIndex) sb.append(',')
+                    sb.append('\n')
+                }
+                sb.append("      ]\n")
+            }
+            sb.append("    }")
+            if (index != adviceEntries.lastIndex) sb.append(',')
+            sb.append('\n')
+        }
+        sb.append("  ]\n")
+        sb.append("}\n")
+        return sb.toString()
+    }
+
+    private fun kindLabel(kind: AdviceKind): String =
+        when (kind) {
+            AdviceKind.BEFORE -> "@Before"
+            AdviceKind.AFTER -> "@After"
+            AdviceKind.AROUND -> "@Around"
+        }
+
+    private fun jsonString(s: String): String {
+        val sb = StringBuilder("\"")
+        for (c in s) {
+            when (c) {
+                '\\' -> sb.append("\\\\")
+                '"' -> sb.append("\\\"")
+                '\n' -> sb.append("\\n")
+                '\r' -> sb.append("\\r")
+                '\t' -> sb.append("\\t")
+                else -> sb.append(c)
+            }
+        }
+        sb.append("\"")
+        return sb.toString()
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrGenerationExtension.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrGenerationExtension.kt
@@ -36,10 +36,30 @@ class AspectKIrGenerationExtension(
         aspects: List<AspectMetadata>,
         matches: Map<AdviceMetadata, List<IrSimpleFunction>>,
     ) {
-        if (!dir.exists() && !dir.mkdirs()) return
-        val sanitized = moduleName.trim('<', '>').replace('/', '_')
-        val out = File(dir, "matches-$sanitized.json")
-        out.writeText(buildReportJson(moduleName, aspects, matches))
+        // The report is non-essential build output — never let an IOException
+        // here fail the user's compilation.
+        runCatching {
+            if (!dir.exists() && !dir.mkdirs()) return@runCatching
+            val out = File(dir, "matches-${sanitizeForFilename(moduleName)}.json")
+            out.writeText(buildReportJson(moduleName, aspects, matches))
+        }
+    }
+
+    /**
+     * Strips characters that are invalid in a filename on common platforms
+     * (Windows is the strictest: `<`, `>`, `:`, `\`, `/`, `*`, `?`, `"`, `|`).
+     * Kotlin module names are commonly bracketed (`<test>`), and may include
+     * `/` in `kotlin.compiler.execution.strategy = in-process` paths.
+     */
+    private fun sanitizeForFilename(name: String): String {
+        val sb = StringBuilder(name.length)
+        for (c in name) {
+            when (c) {
+                '<', '>', ':', '\\', '/', '*', '?', '"', '|' -> sb.append('_')
+                else -> sb.append(c)
+            }
+        }
+        return sb.toString().trim('_').ifEmpty { "module" }
     }
 
     private fun buildReportJson(

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectMetadata.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectMetadata.kt
@@ -62,8 +62,12 @@ internal sealed interface Binding {
     ) : Binding
 
     /** Catch-all binding capturing every value parameter as a `List<Any?>`. */
-    data class ValueParameters(override val adviceParameter: IrValueParameter) : Binding
+    data class ValueParameters(
+        override val adviceParameter: IrValueParameter,
+    ) : Binding
 
     /** Catch-all binding capturing every context parameter as a `List<Any?>`. */
-    data class ContextParameters(override val adviceParameter: IrValueParameter) : Binding
+    data class ContextParameters(
+        override val adviceParameter: IrValueParameter,
+    ) : Binding
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AspectKTransformer.kt
@@ -51,6 +51,15 @@ internal class AspectKTransformer(
     private val aspects: List<AspectMetadata>,
 ) : IrTransformer<Nothing?>() {
     private val aroundWeaver = AroundAdviceWeaver(pluginContext)
+    private val mutableMatches = linkedMapOf<AdviceMetadata, MutableList<IrSimpleFunction>>()
+
+    /**
+     * For each advice the analyzer found, the list of target functions
+     * (in visit order) where it matched. Empty list = the advice's pointcut
+     * matched no targets in this module.
+     */
+    val matches: Map<AdviceMetadata, List<IrSimpleFunction>>
+        get() = mutableMatches
 
     override fun visitElement(
         element: IrElement,
@@ -69,6 +78,7 @@ internal class AspectKTransformer(
         for (aspect in aspects) {
             for (advice in aspect.advices) {
                 if (!PointcutMatcher.matches(advice, declaration)) continue
+                mutableMatches.getOrPut(advice) { mutableListOf() } += declaration
                 applyAdvice(declaration, aspect.aspectClass, advice)
             }
         }
@@ -178,14 +188,16 @@ internal class AspectKTransformer(
         binding: Binding,
         target: IrSimpleFunction,
         builder: DeclarationIrBuilder,
-    ): IrExpression? {
-        return when (binding) {
-            is Binding.DispatchReceiver -> target.parameters
-                .firstOrNull { it.kind == IrParameterKind.DispatchReceiver }
-                ?.let(builder::irGet)
-            is Binding.ExtensionReceiver -> target.parameters
-                .firstOrNull { it.kind == IrParameterKind.ExtensionReceiver }
-                ?.let(builder::irGet)
+    ): IrExpression? =
+        when (binding) {
+            is Binding.DispatchReceiver ->
+                target.parameters
+                    .firstOrNull { it.kind == IrParameterKind.DispatchReceiver }
+                    ?.let(builder::irGet)
+            is Binding.ExtensionReceiver ->
+                target.parameters
+                    .firstOrNull { it.kind == IrParameterKind.ExtensionReceiver }
+                    ?.let(builder::irGet)
             is Binding.ValueParameter -> findRegular(target, binding.index, binding.name)
                 ?.let(builder::irGet)
             is Binding.ContextParameter -> findContext(target, binding.index, binding.name)
@@ -199,7 +211,6 @@ internal class AspectKTransformer(
                 builder,
             )
         }
-    }
 
     /**
      * Builds a `listOf<Any?>(p0, p1, …)` expression that materialises [params]

--- a/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/ExtensionRegistrarConfigurator.kt
+++ b/aspectk-compiler/test-fixtures/com/github/kitakkun/aspectk/compiler/test/services/ExtensionRegistrarConfigurator.kt
@@ -20,6 +20,6 @@ class ExtensionRegistrarConfigurator(
         configuration: CompilerConfiguration,
     ) {
         FirExtensionRegistrarAdapter.registerExtension(AspectKFirExtensionRegistrar())
-        IrGenerationExtension.registerExtension(AspectKIrGenerationExtension())
+        IrGenerationExtension.registerExtension(AspectKIrGenerationExtension(reportDir = null))
     }
 }

--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKKotlinCompilerPluginSupportPlugin.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKKotlinCompilerPluginSupportPlugin.kt
@@ -21,11 +21,17 @@ class AspectKKotlinCompilerPluginSupportPlugin : KotlinCompilerPluginSupportPlug
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
         val project = kotlinCompilation.target.project
         val extension = project.extensions.getByType(AspectKExtension::class.java)
-        val reportDir = project.layout.buildDirectory.dir("reports/aspectk").get().asFile.absolutePath
+        val reportDirProvider = project.layout.buildDirectory.dir("reports/aspectk")
         return project.provider {
+            // Resolve buildDirectory lazily (inside the provider) so any
+            // user-supplied `layout.buildDirectory.set(...)` override applied
+            // after this plugin's `apply` is still picked up.
             listOf(
                 SubpluginOption(key = AspectKSubPluginOptionKey.ENABLED, value = extension.enabled.toString()),
-                SubpluginOption(key = AspectKSubPluginOptionKey.REPORT_DIR, value = reportDir),
+                SubpluginOption(
+                    key = AspectKSubPluginOptionKey.REPORT_DIR,
+                    value = reportDirProvider.get().asFile.absolutePath,
+                ),
             )
         }
     }

--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKKotlinCompilerPluginSupportPlugin.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKKotlinCompilerPluginSupportPlugin.kt
@@ -19,9 +19,14 @@ class AspectKKotlinCompilerPluginSupportPlugin : KotlinCompilerPluginSupportPlug
     }
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
-        val extension = kotlinCompilation.target.project.extensions.getByType(AspectKExtension::class.java)
-        return kotlinCompilation.target.project.provider {
-            listOf(SubpluginOption(key = AspectKSubPluginOptionKey.ENABLED, value = extension.enabled.toString()))
+        val project = kotlinCompilation.target.project
+        val extension = project.extensions.getByType(AspectKExtension::class.java)
+        val reportDir = project.layout.buildDirectory.dir("reports/aspectk").get().asFile.absolutePath
+        return project.provider {
+            listOf(
+                SubpluginOption(key = AspectKSubPluginOptionKey.ENABLED, value = extension.enabled.toString()),
+                SubpluginOption(key = AspectKSubPluginOptionKey.REPORT_DIR, value = reportDir),
+            )
         }
     }
 

--- a/aspectk-plugin-common/src/commonMain/kotlin/com/github/kitakkun/aspectk/plugin/common/AspectKSubPluginOptionKey.kt
+++ b/aspectk-plugin-common/src/commonMain/kotlin/com/github/kitakkun/aspectk/plugin/common/AspectKSubPluginOptionKey.kt
@@ -2,4 +2,5 @@ package com.github.kitakkun.aspectk.plugin.common
 
 object AspectKSubPluginOptionKey {
     const val ENABLED = "enabled"
+    const val REPORT_DIR = "reportDir"
 }


### PR DESCRIPTION
## Summary

Phase 3.x of the v1 roadmap, stacked on #30 (`feat/v1-phase3.x-value-parameters`).

Lays the foundation for the build-time weaving aggregator — the combined successor to the original zero-match diagnostic + weaving report ideas. **Per-compilation step only** in this PR; the Gradle aggregator task that consumes these reports across modules is deferred to a follow-up.

Each compilation unit that contains at least one `@Aspect` now emits a JSON report at `<reportDir>/matches-<module>.json` listing every advice the analyzer found in this module and the local targets it matched. The default `<reportDir>` is `<project.buildDir>/reports/aspectk/`, but can be overridden via the new `reportDir` CLI option.

### Wiring

- New compiler plugin CLI option `reportDir` (`AspectKCommandLineProcessor` + `AspectKCompilerConfigurationKey`).
- New `AspectKSubPluginOptionKey.REPORT_DIR` constant.
- The Gradle plugin (`AspectKKotlinCompilerPluginSupportPlugin`) emits this option pointing at `<project.buildDir>/reports/aspectk/` so the path is automatic for any consumer.
- `AspectKCompilerPluginRegistrar` reads the option and forwards it into `AspectKIrGenerationExtension(reportDir)`.

### Tracking

- `AspectKTransformer.matches` now exposes the full `Map<AdviceMetadata, List<IrSimpleFunction>>` of matched targets (not just hit counts).
- `AspectKIrGenerationExtension.generate` writes the JSON after the transformation pass when `reportDir` is set.

### Report format (verified)

`test/build/reports/aspectk/matches-test.json` after building the `test/` sample:

```json
{
  "module": "<test>",
  "advices": [
    {
      "aspect": "com.github.kitakkun.aspectk.test.GreetingTracer",
      "advice": "aroundGreet",
      "kind": "@Around",
      "targets": [
        { "class": "com.github.kitakkun.aspectk.test.Greeter", "method": "greet" }
      ]
    }
  ]
}
```

Hand-rolled JSON serialisation keeps the compiler-plugin module free of an extra runtime dependency.

### Not in scope for this PR

- The cross-module Gradle aggregator task that reads every `matches-*.json` across the build and emits a global summary + zero-match warning (the original Phase 3.7 idea, deferred under task #21).
- Wiring `@ValueParameters` / `@ContextParameters` into the around weaver — still bails for now (deferred).

## Test plan

- [x] `./gradlew :test:compileKotlinJvm --rerun-tasks` produces `test/build/reports/aspectk/matches-test.json` with the expected structure above.
- [x] `./gradlew build` — green across the repo.
- [x] `./gradlew :aspectk-compiler:test` — 17 tests still green; the in-test ExtensionRegistrarConfigurator passes `reportDir = null` so no spurious reports leak into the framework's temp directories.
