### PR TITLE
fir: reject negative explicit @ValueParameter/@ContextParameter index

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/BindingAnnotationChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/BindingAnnotationChecker.kt
@@ -3,16 +3,21 @@ package com.github.kitakkun.aspectk.compiler.fir.checker
 import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.declarations.evaluateAs
+import org.jetbrains.kotlin.fir.declarations.findArgumentByName
 import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
 
 /**
  * Validates binding annotations on advice value parameters.
  *
- * Two distinct checks run per parameter:
+ * Three distinct checks run per parameter:
  *
  * 1. **Multiple binding annotations on the same parameter** — at most one
  *    of `@DispatchReceiver` / `@ExtensionReceiver` / `@ContextParameter` /
@@ -23,10 +28,15 @@ import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
  *    `index: Int = -1` and `name: String = ""`. Exactly one must be set;
  *    the default-both and both-set forms are rejected so the user gets a
  *    clear diagnostic rather than a silently-mismatching binding at IR time.
+ * 3. **Negative explicit `index`** — when the user writes `index = -1` (the
+ *    annotation default, but explicitly) or any other negative value, the
+ *    binding cannot resolve to a target slot. Reject it so the user gets a
+ *    clear message instead of a silent no-op at IR weaving time. Default
+ *    (omitted) `index` is handled by check (2) via "specify one of index
+ *    or name", not by this check.
  *
  * `@DispatchReceiver`, `@ExtensionReceiver`, `@ValueParameters`, and
- * `@ContextParameters` take no arguments and are not subject to the second
- * check.
+ * `@ContextParameters` take no arguments and are not subject to checks 2/3.
  */
 object BindingAnnotationChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
     private val allBindingAnnotations = listOf(
@@ -65,19 +75,52 @@ object BindingAnnotationChecker : FirSimpleFunctionChecker(MppCheckerKind.Common
                 val annotation = param.getAnnotationByClassId(classId, context.session) ?: continue
                 val hasIndex = AspectKAnnotations.INDEX in annotation.argumentMapping.mapping
                 val hasName = AspectKAnnotations.NAME in annotation.argumentMapping.mapping
-                val message = when {
+                val xorMessage = when {
                     !hasIndex && !hasName -> "specify one of index or name"
                     hasIndex && hasName -> "specify only one of index or name, not both"
-                    else -> continue
+                    else -> null
                 }
-                val src = annotation.source ?: param.source ?: continue
-                reporter.reportOn(
-                    src,
-                    AspectKErrors.INVALID_BINDING_ANNOTATION,
-                    displayName,
-                    message,
-                )
+                if (xorMessage != null) {
+                    val src = annotation.source ?: param.source ?: continue
+                    reporter.reportOn(
+                        src,
+                        AspectKErrors.INVALID_BINDING_ANNOTATION,
+                        displayName,
+                        xorMessage,
+                    )
+                    continue
+                }
+                val explicitIndex = explicitIndexValue(annotation, context.session)
+                if (explicitIndex != null && explicitIndex < 0) {
+                    val src = annotation.source ?: param.source ?: continue
+                    reporter.reportOn(
+                        src,
+                        AspectKErrors.INVALID_BINDING_ANNOTATION,
+                        displayName,
+                        "index must be >= 0 (got $explicitIndex)",
+                    )
+                }
             }
         }
+    }
+
+    /**
+     * Returns the Int the user wrote for `index = N`, or `null` if the
+     * argument is missing or the expression can't be evaluated as a
+     * compile-time integer constant. FIR represents integer literals as
+     * `Long`-valued `FirLiteralExpression`s even when the declared annotation
+     * argument type is `Int`, so we widen to `Number` and call `.toInt()`.
+     */
+    private fun explicitIndexValue(
+        annotation: FirAnnotation,
+        session: FirSession,
+    ): Int? {
+        val expr = annotation.findArgumentByName(AspectKAnnotations.INDEX)
+            ?: annotation.argumentMapping.mapping[AspectKAnnotations.INDEX]
+            ?: return null
+        val literal = expr.evaluateAs<FirLiteralExpression>(session)
+            ?: (expr as? FirLiteralExpression)
+            ?: return null
+        return (literal.value as? Number)?.toInt()
     }
 }

--- a/aspectk-compiler/testData/diagnostics/bindingAnnotationNegativeIndex.fir.txt
+++ b/aspectk-compiler/testData/diagnostics/bindingAnnotationNegativeIndex.fir.txt
@@ -1,0 +1,19 @@
+FILE: BindingAnnotationNegativeIndex.kt
+    @R|com/github/kitakkun/aspectk/annotations/Aspect|() public final class NegativeIndexAspect : R|kotlin/Any| {
+        public constructor(): R|NegativeIndexAspect| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|() @R|com/github/kitakkun/aspectk/annotations/MethodName|(pattern = String(greet)) public final fun beforeNegativeIndex(@R|com/github/kitakkun/aspectk/annotations/ValueParameter|(index = Int(-1)) name: R|kotlin/String|): R|kotlin/Unit| {
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|() @R|com/github/kitakkun/aspectk/annotations/MethodName|(pattern = String(greet)) public final fun beforeNegativeIndexFar(@R|com/github/kitakkun/aspectk/annotations/ValueParameter|(index = Int(-5)) name: R|kotlin/String|): R|kotlin/Unit| {
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|() @R|com/github/kitakkun/aspectk/annotations/MethodName|(pattern = String(greet)) public final fun beforeNegativeContextIndex(@R|com/github/kitakkun/aspectk/annotations/ContextParameter|(index = Int(-1)) ctx: R|kotlin/String|): R|kotlin/Unit| {
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|() @R|com/github/kitakkun/aspectk/annotations/MethodName|(pattern = String(greet)) public final fun beforeOkIndex(@R|com/github/kitakkun/aspectk/annotations/ValueParameter|(index = Int(0)) name: R|kotlin/String|): R|kotlin/Unit| {
+        }
+
+    }

--- a/aspectk-compiler/testData/diagnostics/bindingAnnotationNegativeIndex.kt
+++ b/aspectk-compiler/testData/diagnostics/bindingAnnotationNegativeIndex.kt
@@ -1,0 +1,34 @@
+// FILE: BindingAnnotationNegativeIndex.kt
+
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.ContextParameter
+import com.github.kitakkun.aspectk.annotations.MethodName
+import com.github.kitakkun.aspectk.annotations.ValueParameter
+
+@Aspect
+class NegativeIndexAspect {
+    @Before
+    @MethodName("greet")
+    fun beforeNegativeIndex(
+        <!INVALID_BINDING_ANNOTATION!>@ValueParameter(index = -1)<!> name: String,
+    ) {}
+
+    @Before
+    @MethodName("greet")
+    fun beforeNegativeIndexFar(
+        <!INVALID_BINDING_ANNOTATION!>@ValueParameter(index = -5)<!> name: String,
+    ) {}
+
+    @Before
+    @MethodName("greet")
+    fun beforeNegativeContextIndex(
+        <!INVALID_BINDING_ANNOTATION!>@ContextParameter(index = -1)<!> ctx: String,
+    ) {}
+
+    @Before
+    @MethodName("greet")
+    fun beforeOkIndex(
+        @ValueParameter(index = 0) name: String,
+    ) {}
+}


### PR DESCRIPTION
## Summary

Closes the `@ValueParameter(index = -1)` silent-skip footgun. Previously the IR weaver normalized negative explicit indices to `null` in `readIndexNameArgs` and dropped the binding without diagnostics; the user got no feedback that their advice never wove. `BindingAnnotationChecker` now rejects negative explicit `index` values at FIR time.

## Behavior

| User wrote | Previously | Now |
|---|---|---|
| `` `@ValueParameter` ``(no args) | xor diag: "specify one of index or name" | unchanged |
| `` `@ValueParameter` ``(index = 0, name = "x") | xor diag: "specify only one" | unchanged |
| `` `@ValueParameter` ``(index = 0) | accepted | unchanged |
| `` `@ValueParameter` ``(name = "x") | accepted | unchanged |
| `` `@ValueParameter` ``(index = -1) | accepted, silent skip at IR | `INVALID_BINDING_ANNOTATION` — `index must be >= 0 (got -1)` |
| `` `@ValueParameter` ``(index = -5) | accepted, silent skip at IR | same diagnostic, `(got -5)` |
| `` `@ContextParameter` ``(index = -1) | accepted, silent skip at IR | same diagnostic |

The xor check still runs first, so omitted-args still produce the existing "specify one of index or name" message rather than the new "must be >= 0" one. Default-omitted indices reach the new check at all because `argumentMapping.mapping` only contains keys the user explicitly wrote.

## Implementation note

FIR represents integer literals as `FirLiteralExpression` with `Long`-valued `.value`, even when the declared annotation argument type is `Int`. The earlier draft cast directly to `Int` and silently returned `null`, dropping the diagnostic. The current code widens through `Number.toInt()`. Resolution path is:

1. `findArgumentByName(INDEX)` — primary; gives back the expression a user typed.
2. Fallback to `argumentMapping.mapping[INDEX]` — covers any phase where (1) returns null.
3. `evaluateAs<FirLiteralExpression>(session)` — folds `unaryMinus(1)` if FIR hasn't already.
4. `value as? Number → .toInt()` — handles the `Long`/`Int` quirk above.

## Test plan

- [x] `./gradlew :aspectk-compiler:test --rerun-tasks` green locally.
- [x] New diagnostic test `bindingAnnotationNegativeIndex.kt` covers `index = -1`, `index = -5`, `` `@ContextParameter` `` negative, and a positive control case.
- [ ] CI on `feat/v1` green after rebase.
