### PR TITLE
fir: require advice to declare at least one matching annotation

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AdviceMatchingRequiredChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AdviceMatchingRequiredChecker.kt
@@ -1,0 +1,59 @@
+package com.github.kitakkun.aspectk.compiler.fir.checker
+
+import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.name.ClassId
+
+/**
+ * An advice function (`@Before` / `@After` / `@Around`) must declare at least
+ * one matching annotation that bounds the set of targets it intercepts. With
+ * none, the advice would either match nothing (silently) or every function
+ * AspectK sees, depending on how the matcher treats missing pointcuts —
+ * neither is what the user likely wants.
+ *
+ * Matching annotations are `@Package`, `@ClassName`, `@MethodName`,
+ * `@Visibility`, `@Modality`, `@Modifiers`, `@Annotated`.
+ *
+ * This checker complements [PointcutAnnotationChecker]'s pattern-string
+ * validation: that checker rejects empty patterns on individual annotations;
+ * this one rejects the case where no matching annotation is present at all.
+ */
+object AdviceMatchingRequiredChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+    private val MATCHING_ANNOTATIONS: List<ClassId> = listOf(
+        AspectKAnnotations.PACKAGE_CLASS_ID,
+        AspectKAnnotations.CLASS_NAME_CLASS_ID,
+        AspectKAnnotations.METHOD_NAME_CLASS_ID,
+        AspectKAnnotations.VISIBILITY_CLASS_ID,
+        AspectKAnnotations.MODALITY_CLASS_ID,
+        AspectKAnnotations.MODIFIERS_CLASS_ID,
+        AspectKAnnotations.ANNOTATED_CLASS_ID,
+    )
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirNamedFunction) {
+        val adviceKind = adviceKindOn(declaration) ?: return
+        if (MATCHING_ANNOTATIONS.any { declaration.hasAnnotation(it, context.session) }) return
+
+        val src = declaration.source ?: return
+        reporter.reportOn(
+            src,
+            AspectKErrors.ADVICE_HAS_NO_MATCHING_ANNOTATION,
+            adviceKind,
+        )
+    }
+
+    context(context: CheckerContext)
+    private fun adviceKindOn(declaration: FirNamedFunction): String? =
+        when {
+            declaration.hasAnnotation(AspectKAnnotations.BEFORE_CLASS_ID, context.session) -> "Before"
+            declaration.hasAnnotation(AspectKAnnotations.AFTER_CLASS_ID, context.session) -> "After"
+            declaration.hasAnnotation(AspectKAnnotations.AROUND_CLASS_ID, context.session) -> "Around"
+            else -> null
+        }
+}

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
@@ -25,6 +25,15 @@ object AspectKErrors : KtDiagnosticsContainer() {
     val INVALID_BINDING_ANNOTATION by error2<KtAnnotationEntry, String, String>()
 
     /**
+     * Advice (`@Before` / `@After` / `@Around`) declared without any matching
+     * annotation (`@Package` / `@ClassName` / `@MethodName` / `@Visibility` /
+     * `@Modality` / `@Modifiers` / `@Annotated`). Such advice would match an
+     * unbounded set of targets — almost always a mistake — so we reject it at
+     * FIR time rather than letting the IR weaver run unconstrained.
+     */
+    val ADVICE_HAS_NO_MATCHING_ANNOTATION by error1<KtFunction, String>()
+
+    /**
      * A function call site is woven by an `@Around` / `@Before` / `@After`
      * advice. Surfaces as a weak compiler diagnostic so IntelliJ shows an
      * inline marker. The single argument is the woven advice's FQN + kind,
@@ -76,6 +85,11 @@ private object AspectKDefaultMessages : BaseDiagnosticRendererFactory() {
         map.put(
             AspectKErrors.AROUND_UNSUPPORTED_BINDING,
             "@Around advice not woven: {0}",
+            CommonRenderers.STRING,
+        )
+        map.put(
+            AspectKErrors.ADVICE_HAS_NO_MATCHING_ANNOTATION,
+            "@{0} advice declares no matching annotation (@Package / @ClassName / @MethodName / @Visibility / @Modality / @Modifiers / @Annotated). Add at least one to bound the targets it intercepts.",
             CommonRenderers.STRING,
         )
     }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKFirCheckerExtension.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKFirCheckerExtension.kt
@@ -19,6 +19,7 @@ class AspectKFirCheckerExtension(
             AdviceScopeChecker,
             PointcutAnnotationChecker,
             BindingAnnotationChecker,
+            AdviceMatchingRequiredChecker,
         )
     }
 

--- a/aspectk-compiler/testData/diagnostics/adviceHasNoMatchingAnnotation.fir.txt
+++ b/aspectk-compiler/testData/diagnostics/adviceHasNoMatchingAnnotation.fir.txt
@@ -1,0 +1,22 @@
+FILE: AdviceHasNoMatchingAnnotation.kt
+    @R|com/github/kitakkun/aspectk/annotations/Aspect|() public final class Unbounded : R|kotlin/Any| {
+        public constructor(): R|Unbounded| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|() public final fun beforeAll(): R|kotlin/Unit| {
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/After|() public final fun afterAll(): R|kotlin/Unit| {
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Around|() public final fun aroundAll(): R|kotlin/Unit| {
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|() @R|com/github/kitakkun/aspectk/annotations/MethodName|(pattern = String(greet)) public final fun beforeNamed(): R|kotlin/Unit| {
+        }
+
+        @R|com/github/kitakkun/aspectk/annotations/Before|() @R|com/github/kitakkun/aspectk/annotations/ClassName|(pattern = String(Greeter)) public final fun beforeAnyMethodInGreeter(): R|kotlin/Unit| {
+        }
+
+    }

--- a/aspectk-compiler/testData/diagnostics/adviceHasNoMatchingAnnotation.kt
+++ b/aspectk-compiler/testData/diagnostics/adviceHasNoMatchingAnnotation.kt
@@ -1,0 +1,36 @@
+// FILE: AdviceHasNoMatchingAnnotation.kt
+
+import com.github.kitakkun.aspectk.annotations.After
+import com.github.kitakkun.aspectk.annotations.Around
+import com.github.kitakkun.aspectk.annotations.Aspect
+import com.github.kitakkun.aspectk.annotations.Before
+import com.github.kitakkun.aspectk.annotations.ClassName
+import com.github.kitakkun.aspectk.annotations.MethodName
+
+@Aspect
+class Unbounded {
+    // @Before with no matching annotation — flagged.
+    <!ADVICE_HAS_NO_MATCHING_ANNOTATION!>@Before
+    fun beforeAll() {}<!>
+
+    // @After likewise.
+    <!ADVICE_HAS_NO_MATCHING_ANNOTATION!>@After
+    fun afterAll() {}<!>
+
+    // @Around likewise. (body is empty to keep the test focused on the
+    // missing-matching-annotation diagnostic — IR-level @Around requires
+    // an `interceptableAdvice { ... }` body, but this test only exercises
+    // the FIR pipeline.)
+    <!ADVICE_HAS_NO_MATCHING_ANNOTATION!>@Around
+    fun aroundAll() {}<!>
+
+    // A single matching annotation is enough — not flagged.
+    @Before
+    @MethodName("greet")
+    fun beforeNamed() {}
+
+    // @ClassName-only is sufficient.
+    @Before
+    @ClassName("Greeter")
+    fun beforeAnyMethodInGreeter() {}
+}


### PR DESCRIPTION
## Summary

Closes the "advice with no matching annotation matches everything" footgun. Previously a user could write:

```kotlin
@Aspect
class Tracer {
    @Before
    fun beforeEverything() = println("…")
}
```

…and the IR weaver would weave that `@Before` into every function in the module because `PointcutMatcher.filterMatches` returns `true` when all constraint fields are `null`. The user got no feedback at FIR time that they'd asked for unbounded matching.

`AdviceMatchingRequiredChecker` now rejects this at FIR time: an advice that declares none of `@Package` / `@ClassName` / `@MethodName` / `@Visibility` / `@Modality` / `@Modifiers` / `@Annotated` produces `ADVICE_HAS_NO_MATCHING_ANNOTATION`.

## Examples

| Advice form | Behavior |
|---|---|
| `` `@Before` `` (alone) | error `ADVICE_HAS_NO_MATCHING_ANNOTATION` — "@Before advice declares no matching annotation …" |
| `` `@After` `` (alone) | same |
| `` `@Around` `` (alone) | same |
| `` `@Before` `` + `` `@MethodName` ``(...) | accepted |
| `` `@Before` `` + `` `@ClassName` ``(...) | accepted |
| `` `@Before` `` + `` `@Annotated` ``(...) | accepted |

A single matching annotation is enough to satisfy the check — combinations are not required.

## Implementation

Standalone `FirSimpleFunctionChecker` placed alongside the existing `PointcutAnnotationChecker`/`BindingAnnotationChecker`/`AdviceScopeChecker`. The four checkers have orthogonal concerns:

- `AdviceScopeChecker` — advice must live inside an `` `@Aspect` `` class.
- `PointcutAnnotationChecker` — per-annotation pattern strings can't be empty.
- `BindingAnnotationChecker` — value-parameter binding annotations are well-formed.
- `AdviceMatchingRequiredChecker` (new) — at least one matching annotation exists.

Registered after the other three in `AspectKFirCheckerExtension.declarationCheckers.simpleFunctionCheckers`.

## Test plan

- [x] `./gradlew :aspectk-compiler:test --rerun-tasks` green locally (no existing test had advice without a matching annotation, so nothing else needed updating).
- [x] New diagnostic test `adviceHasNoMatchingAnnotation.kt` covers `@Before` / `@After` / `@Around` flagged, and `@Before+@MethodName` / `@Before+@ClassName` accepted.
- [ ] CI on `feat/v1` green after rebase.

## Note on `@Around` body in the test

The `@Around` negative case uses `fun aroundAll() {}` (empty body) instead of `interceptableAdvice { proceed() }`. Reason: when an unbounded `@Before`/`@After`/`@Around` exists in scope, `WovenCallSiteChecker` matches every function call site (it currently treats `classNamePattern == null && methodNamePattern == null` as "match all") and emits `WOVEN_CALL_SITE` markers on every call. With `interceptableAdvice { proceed() }`, that adds two cascading warnings on the `@Around` body that have nothing to do with this PR's check. Empty body keeps the test focused. The `@Around`'s shape doesn't affect what `AdviceMatchingRequiredChecker` does — it only inspects annotations.
