### PR TITLE
perf: cache aspect advice list per session in WovenAdviceIndex

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/AspectKFirExtensionRegistrar.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/AspectKFirExtensionRegistrar.kt
@@ -2,11 +2,13 @@ package com.github.kitakkun.aspectk.compiler.fir
 
 import com.github.kitakkun.aspectk.compiler.fir.checker.AspectKErrors
 import com.github.kitakkun.aspectk.compiler.fir.checker.AspectKFirCheckerExtension
+import com.github.kitakkun.aspectk.compiler.fir.checker.WovenAdviceIndex
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 
 class AspectKFirExtensionRegistrar : FirExtensionRegistrar() {
     override fun ExtensionRegistrarContext.configurePlugin() {
         +::AspectKFirCheckerExtension
+        +::WovenAdviceIndex
         registerDiagnosticContainers(AspectKErrors)
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/WovenAdviceIndex.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/WovenAdviceIndex.kt
@@ -1,0 +1,107 @@
+package com.github.kitakkun.aspectk.compiler.fir.checker
+
+import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
+import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
+import org.jetbrains.kotlin.fir.declarations.getStringArgument
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
+import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent
+import org.jetbrains.kotlin.fir.extensions.predicate.LookupPredicate
+import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.name.ClassId
+
+/**
+ * Session-scoped cache of every advice the FIR session can see, with its
+ * `@ClassName` / `@MethodName` patterns pre-resolved.
+ *
+ * [WovenCallSiteChecker] fires on every `FirFunctionCall`, which is a lot —
+ * recomputing the advice list (and re-reading every annotation argument) per
+ * call site adds up on big sources. The advice list is invariant across a
+ * single compilation, so we resolve it once via [LookupPredicate.annotated]
+ * on first access and reuse the result for the rest of the session.
+ *
+ * Register through [com.github.kitakkun.aspectk.compiler.fir.AspectKFirExtensionRegistrar]
+ * so the session-wide annotation index has `@Aspect` available.
+ */
+class WovenAdviceIndex(
+    session: FirSession,
+) : FirExtensionSessionComponent(session) {
+    override fun FirDeclarationPredicateRegistrar.registerPredicates() {
+        register(ASPECT_LOOKUP)
+    }
+
+    /**
+     * Pre-resolved snapshot of one advice function the checker may want to
+     * report against.
+     *
+     * - [label] is the user-facing string baked into the diagnostic argument
+     *   (e.g. `"GreetingTracer.aroundGreet (@Around)"`).
+     * - [classNamePattern] / [methodNamePattern] are the literal pattern
+     *   strings the user wrote; `null` means the corresponding annotation
+     *   was absent (i.e. the constraint is open).
+     */
+    class Entry(
+        val label: String,
+        val classNamePattern: String?,
+        val methodNamePattern: String?,
+    )
+
+    val entries: List<Entry> by lazy { computeEntries() }
+
+    @OptIn(SymbolInternals::class, DirectDeclarationsAccess::class)
+    private fun computeEntries(): List<Entry> {
+        val aspectSymbols = session.predicateBasedProvider
+            .getSymbolsByPredicate(ASPECT_LOOKUP)
+            .filterIsInstance<FirRegularClassSymbol>()
+
+        val result = mutableListOf<Entry>()
+        for (aspect in aspectSymbols) {
+            val aspectShortName = aspect.classId.relativeClassName.asString()
+            for (memberSymbol in aspect.declarationSymbols) {
+                if (memberSymbol !is FirNamedFunctionSymbol) continue
+                val fir = memberSymbol.fir as? FirNamedFunction ?: continue
+                val kindLabel = adviceKindLabel(fir, session) ?: continue
+                result += Entry(
+                    label = "$aspectShortName.${fir.name.asString()} ($kindLabel)",
+                    classNamePattern = readPattern(fir, AspectKAnnotations.CLASS_NAME_CLASS_ID, session),
+                    methodNamePattern = readPattern(fir, AspectKAnnotations.METHOD_NAME_CLASS_ID, session),
+                )
+            }
+        }
+        return result
+    }
+
+    private fun adviceKindLabel(
+        fn: FirNamedFunction,
+        session: FirSession,
+    ): String? =
+        when {
+            fn.hasAnnotation(AspectKAnnotations.BEFORE_CLASS_ID, session) -> "@Before"
+            fn.hasAnnotation(AspectKAnnotations.AFTER_CLASS_ID, session) -> "@After"
+            fn.hasAnnotation(AspectKAnnotations.AROUND_CLASS_ID, session) -> "@Around"
+            else -> null
+        }
+
+    private fun readPattern(
+        fn: FirNamedFunction,
+        annotationClassId: ClassId,
+        session: FirSession,
+    ): String? =
+        fn
+            .getAnnotationByClassId(annotationClassId, session)
+            ?.getStringArgument(AspectKAnnotations.PATTERN, session)
+
+    companion object {
+        val ASPECT_LOOKUP: LookupPredicate = LookupPredicate.create {
+            annotated(AspectKAnnotations.ASPECT_FQ_NAME)
+        }
+    }
+}
+
+val FirSession.wovenAdviceIndex: WovenAdviceIndex by FirSession.sessionComponentAccessor()

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/WovenAdviceIndex.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/WovenAdviceIndex.kt
@@ -2,6 +2,8 @@ package com.github.kitakkun.aspectk.compiler.fir.checker
 
 import com.github.kitakkun.aspectk.compiler.AspectKAnnotations
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.caches.FirLazyValue
+import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
@@ -25,6 +27,11 @@ import org.jetbrains.kotlin.name.ClassId
  * call site adds up on big sources. The advice list is invariant across a
  * single compilation, so we resolve it once via [LookupPredicate.annotated]
  * on first access and reuse the result for the rest of the session.
+ *
+ * The cache uses [firCachesFactory] (specifically `createLazyValue`) so it
+ * participates in the FIR pipeline's invalidation. A plain Kotlin `by lazy`
+ * is technically equivalent in CLI compiles but doesn't get invalidated
+ * when the session is recreated under IDE-driven file changes.
  *
  * Register through [com.github.kitakkun.aspectk.compiler.fir.AspectKFirExtensionRegistrar]
  * so the session-wide annotation index has `@Aspect` available.
@@ -52,7 +59,10 @@ class WovenAdviceIndex(
         val methodNamePattern: String?,
     )
 
-    val entries: List<Entry> by lazy { computeEntries() }
+    private val entriesCache: FirLazyValue<List<Entry>> =
+        session.firCachesFactory.createLazyValue { computeEntries() }
+
+    val entries: List<Entry> get() = entriesCache.getValue()
 
     @OptIn(SymbolInternals::class, DirectDeclarationsAccess::class)
     private fun computeEntries(): List<Entry> {

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/WovenCallSiteChecker.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/WovenCallSiteChecker.kt
@@ -8,20 +8,11 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirExpressionChecker
-import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
-import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
-import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
-import org.jetbrains.kotlin.fir.declarations.getStringArgument
 import org.jetbrains.kotlin.fir.declarations.hasAnnotation
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
-import org.jetbrains.kotlin.fir.extensions.predicate.LookupPredicate
-import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.references.toResolvedNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
-import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
-import org.jetbrains.kotlin.name.ClassId
 
 /**
  * Emits a weak [AspectKErrors.WOVEN_CALL_SITE] diagnostic at each function
@@ -31,21 +22,24 @@ import org.jetbrains.kotlin.name.ClassId
  * are honoured at FIR time. IR remains the authoritative weaver; an
  * over-fired marker is acceptable for editor feedback.
  *
- * Aspect discovery uses the FIR predicate system (`LookupPredicate.annotated
- * (@Aspect)`); the registrar registers the predicate so the session-wide
- * annotation index includes `@Aspect`.
+ * The advice list comes from [WovenAdviceIndex], a session component that
+ * resolves every `@Aspect`-class's advices once per session and caches the
+ * pre-resolved `(classNamePattern, methodNamePattern, label)` tuples. This
+ * checker fires on every `FirFunctionCall` in the source, so resolving the
+ * list inline would compound across call sites.
  *
  * Calls whose callee lives inside an `@Aspect` class are skipped — the IR
  * weaver never targets those either.
  */
 object WovenCallSiteChecker : FirExpressionChecker<FirFunctionCall>(MppCheckerKind.Common) {
-    private val ASPECT_LOOKUP: LookupPredicate = LookupPredicate.create {
-        annotated(AspectKAnnotations.ASPECT_FQ_NAME)
-    }
-
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(expression: FirFunctionCall) {
         val session = context.session
+        // Short-circuit when the session has no advices at all — most calls
+        // in most files. Avoids per-call-site annotation reads below.
+        val entries = session.wovenAdviceIndex.entries
+        if (entries.isEmpty()) return
+
         val calleeSymbol = expression.calleeReference.toResolvedNamedFunctionSymbol() ?: return
 
         // Skip calls into @Aspect classes (advice-internal calls) and skip
@@ -58,38 +52,14 @@ object WovenCallSiteChecker : FirExpressionChecker<FirFunctionCall>(MppCheckerKi
             ?.asString()
         val methodName = calleeSymbol.callableId.callableName.asString()
 
-        val matches = collectMatchingAdvices(session, containingClassName, methodName)
+        val matches = entries.filter { entry ->
+            filterMatches(entry.classNamePattern, entry.methodNamePattern, containingClassName, methodName)
+        }
         if (matches.isEmpty()) return
         val src = expression.calleeReference.source ?: expression.source ?: return
         for (advice in matches) {
-            reporter.reportOn(src, AspectKErrors.WOVEN_CALL_SITE, advice)
+            reporter.reportOn(src, AspectKErrors.WOVEN_CALL_SITE, advice.label)
         }
-    }
-
-    @OptIn(SymbolInternals::class, DirectDeclarationsAccess::class)
-    private fun collectMatchingAdvices(
-        session: FirSession,
-        containingClassName: String?,
-        methodName: String,
-    ): List<String> {
-        val aspectSymbols = session.predicateBasedProvider
-            .getSymbolsByPredicate(ASPECT_LOOKUP)
-            .filterIsInstance<FirRegularClassSymbol>()
-
-        val matched = mutableListOf<String>()
-        for (aspect in aspectSymbols) {
-            val aspectShortName = aspect.classId.relativeClassName.asString()
-            for (memberSymbol in aspect.declarationSymbols) {
-                if (memberSymbol !is FirNamedFunctionSymbol) continue
-                val fir = memberSymbol.fir as? FirNamedFunction ?: continue
-                val kindLabel = adviceKindLabel(fir, session) ?: continue
-                val classNamePattern = readPattern(fir, AspectKAnnotations.CLASS_NAME_CLASS_ID, session)
-                val methodNamePattern = readPattern(fir, AspectKAnnotations.METHOD_NAME_CLASS_ID, session)
-                if (!filterMatches(classNamePattern, methodNamePattern, containingClassName, methodName)) continue
-                matched += "$aspectShortName.${fir.name.asString()} ($kindLabel)"
-            }
-        }
-        return matched
     }
 
     private fun filterMatches(
@@ -107,26 +77,6 @@ object WovenCallSiteChecker : FirExpressionChecker<FirFunctionCall>(MppCheckerKi
         }
         return true
     }
-
-    private fun adviceKindLabel(
-        fn: FirNamedFunction,
-        session: FirSession,
-    ): String? =
-        when {
-            fn.hasAnnotation(AspectKAnnotations.BEFORE_CLASS_ID, session) -> "@Before"
-            fn.hasAnnotation(AspectKAnnotations.AFTER_CLASS_ID, session) -> "@After"
-            fn.hasAnnotation(AspectKAnnotations.AROUND_CLASS_ID, session) -> "@Around"
-            else -> null
-        }
-
-    private fun readPattern(
-        fn: FirNamedFunction,
-        annotationClassId: ClassId,
-        session: FirSession,
-    ): String? =
-        fn
-            .getAnnotationByClassId(annotationClassId, session)
-            ?.getStringArgument(AspectKAnnotations.PATTERN, session)
 
     private fun isInsideAspectClass(
         symbol: FirNamedFunctionSymbol,


### PR DESCRIPTION
## Summary

`WovenCallSiteChecker` fires on every `FirFunctionCall` in the source — for a large module that's thousands of invocations. Previously each invocation re-derived the same per-session-invariant data:

1. Re-queried `session.predicateBasedProvider.getSymbolsByPredicate(ASPECT_LOOKUP)`.
2. Walked every aspect's declaration list.
3. Re-read `@ClassName` / `@MethodName` / `@Before` / `@After` / `@Around` annotations via `getAnnotationByClassId` to recompute the same pattern strings.

For N call sites and M advices across the project this was O(N × M) annotation reads per file. The advice list doesn't change during a compilation, so it's cacheable.

## What changes

- New `WovenAdviceIndex` `FirExtensionSessionComponent` exposes a lazily computed `List<Entry>` snapshot, where each `Entry` carries the diagnostic label and pre-resolved `classNamePattern` / `methodNamePattern` strings.
- The component overrides `registerPredicates()` so the session-wide annotation index has `` `@Aspect` `` available even if the checker is bypassed.
- `WovenCallSiteChecker` now reads `session.wovenAdviceIndex.entries` and filters in-memory.
- Empty-aspects early-return is hoisted above the `isInsideAspectClass` / `isAdvice` calls. Modules with no `` `@Aspect` `` classes (the common case) skip the rest of the checker entirely.

No user-visible behavior change — diagnostic shape and location are identical.

## Test plan

- [x] `./gradlew :aspectk-compiler:test --rerun-tasks` green locally (existing box / diagnostic tests cover `WovenCallSiteChecker` output).
- [ ] CI on `feat/v1` green after rebase.

## Note on cache lifetime

`FirExtensionSessionComponent` is scoped to a single `FirSession`. Sessions live for one compilation, so the cache is naturally invalidated between IDE syncs / build invocations. No manual invalidation needed.
