### PR TITLE
feat: diagnose @Around silent-skip cases at IR weaving time

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/transformer/AroundAdviceWeaver.kt
@@ -105,10 +105,36 @@ internal class AroundAdviceWeaver(
         }
 
         val adviceFn = advice.function
-        val lambdaFn = findAdviceLambda(adviceFn) ?: return false
-        val adviceLambdaBody = lambdaFn.body as? IrBlockBody ?: return false
+        val lambdaFn = findAdviceLambda(adviceFn) ?: run {
+            pluginContext.diagnosticReporter
+                .at(advice.function)
+                .report(
+                    AspectKErrors.AROUND_NOT_WOVEN,
+                    "advice body must be exactly `interceptableAdvice<R> { ... }` (a single-return expression body, " +
+                        "no other statements). Move setup/teardown into the lambda block.",
+                )
+            return false
+        }
+        val adviceLambdaBody = lambdaFn.body as? IrBlockBody ?: run {
+            pluginContext.diagnosticReporter
+                .at(advice.function)
+                .report(
+                    AspectKErrors.AROUND_NOT_WOVEN,
+                    "advice's `interceptableAdvice { ... }` lambda must have a block body.",
+                )
+            return false
+        }
 
-        val originalReturnValue = singleReturnValue(target) ?: return false
+        val originalReturnValue = singleReturnValue(target) ?: run {
+            pluginContext.diagnosticReporter
+                .at(target)
+                .report(
+                    AspectKErrors.AROUND_NOT_WOVEN,
+                    "target `${target.name.asString()}` has a body shape the @Around weaver can't substitute: " +
+                        "expected a single `return <expr>` statement.",
+                )
+            return false
+        }
 
         val builder = DeclarationIrBuilder(
             pluginContext,
@@ -146,6 +172,7 @@ internal class AroundAdviceWeaver(
             //    replace* calls, proceed() calls, and lambda-targeted returns.
             val clonedBody = adviceLambdaBody.deepCopyWithSymbols(initialParent = target)
             val substitution = AroundSubstitutionTransformer(
+                pluginContext = pluginContext,
                 builder = builder,
                 paramToLocal = paramToLocal,
                 slotToLocal = slotToLocal,
@@ -215,6 +242,7 @@ internal class AroundAdviceWeaver(
 }
 
 private class AroundSubstitutionTransformer(
+    private val pluginContext: IrPluginContext,
     private val builder: DeclarationIrBuilder,
     private val paramToLocal: Map<IrValueParameter, IrVariable>,
     private val slotToLocal: Map<IrValueParameter, IrVariable>,
@@ -288,40 +316,45 @@ private class AroundSubstitutionTransformer(
     /**
      * If [call] is a recognised `AroundScope.replace*` invocation with a
      * constant slot identifier that resolves to a target parameter, returns
-     * that target parameter. Returns `null` otherwise.
-     *
-     * Caveat: returning null here can mean either "not a `replace*` call at
-     * all" or "a `replace*` call whose slot key isn't a compile-time
-     * constant". The visitCall caller treats both as fall-through; the
-     * latter case leaves the original `AroundScope.replace*` call in place,
-     * which would crash at runtime via the `aspectk-core` stub. A dedicated
-     * UNRESOLVED_REPLACE_SLOT diagnostic is tracked under task #26 (FIR
-     * pointcut-completeness check), where the necessary diagnostic-factory
-     * plumbing already lives.
+     * that target parameter. Returns `null` if the call isn't a `replace*`
+     * call at all. If the call IS a `replace*` but its slot identifier isn't
+     * a compile-time constant, an `AROUND_REPLACE_SLOT_UNRESOLVED` warning is
+     * reported (the call is then left as the runtime-throwing stub).
      */
     private fun replaceCallTargetSlot(call: IrCall): IrValueParameter? {
         val callee = call.symbol.owner
         val owner = callee.parentClassOrNull ?: return null
         if (owner.kotlinFqName != AspectKAnnotations.AROUND_SCOPE_FQ_NAME) return null
-        return when (callee.name.asString()) {
+        val fnName = callee.name.asString()
+        return when (fnName) {
             "replaceDispatchReceiver" ->
                 target.parameters.firstOrNull { it.kind == IrParameterKind.DispatchReceiver }
             "replaceExtensionReceiver" ->
                 target.parameters.firstOrNull { it.kind == IrParameterKind.ExtensionReceiver }
             "replaceValueParameter" ->
-                resolveSlotByConstArg(call, target.parameters.filter { it.kind == IrParameterKind.Regular })
+                resolveSlotByConstArg(call, fnName, target.parameters.filter { it.kind == IrParameterKind.Regular })
             "replaceContextParameter" ->
-                resolveSlotByConstArg(call, target.parameters.filter { it.kind == IrParameterKind.Context })
+                resolveSlotByConstArg(call, fnName, target.parameters.filter { it.kind == IrParameterKind.Context })
             else -> null
         }
     }
 
     private fun resolveSlotByConstArg(
         call: IrCall,
+        fnName: String,
         candidates: List<IrValueParameter>,
     ): IrValueParameter? {
         // arguments layout: [dispatchReceiver, slotKey, value]
-        val keyArg = call.arguments.getOrNull(1) as? IrConst ?: return null
+        val keyArg = call.arguments.getOrNull(1) as? IrConst
+        if (keyArg == null) {
+            pluginContext.diagnosticReporter
+                .at(call, target)
+                .report(
+                    AspectKErrors.AROUND_REPLACE_SLOT_UNRESOLVED,
+                    fnName,
+                )
+            return null
+        }
         return when (val key = keyArg.value) {
             is Int -> candidates.getOrNull(key)
             is String -> candidates.firstOrNull { it.name.asString() == key }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/fir/checker/AspectKErrors.kt
@@ -40,6 +40,25 @@ object AspectKErrors : KtDiagnosticsContainer() {
      */
     val AROUND_UNSUPPORTED_BINDING by warning1<KtElement, String>()
 
+    /**
+     * `@Around` advice silently skipped because the advice's body or its
+     * matched target has a shape the weaver doesn't support. The single
+     * argument is the reason (e.g. "advice body must be exactly
+     * `interceptableAdvice<R> { … }`"). Complementary to
+     * [AROUND_UNSUPPORTED_BINDING], which is specific to binding shapes.
+     */
+    val AROUND_NOT_WOVEN by warning1<KtElement, String>()
+
+    /**
+     * `AroundScope.replaceValueParameter(slot, value)` or
+     * `replaceContextParameter(slot, value)` was called with a `slot` argument
+     * the weaver couldn't resolve to a compile-time constant `Int` index or
+     * `String` name. The call is left as the runtime-throwing `aspectk-core`
+     * stub; this warning surfaces that the override won't take effect. The
+     * argument is the `replace*` function name.
+     */
+    val AROUND_REPLACE_SLOT_UNRESOLVED by warning1<KtElement, String>()
+
     override fun getRendererFactory(): BaseDiagnosticRendererFactory = AspectKDefaultMessages
 }
 
@@ -76,6 +95,16 @@ private object AspectKDefaultMessages : BaseDiagnosticRendererFactory() {
         map.put(
             AspectKErrors.AROUND_UNSUPPORTED_BINDING,
             "@Around advice not woven: {0}",
+            CommonRenderers.STRING,
+        )
+        map.put(
+            AspectKErrors.AROUND_NOT_WOVEN,
+            "@Around advice not woven: {0}",
+            CommonRenderers.STRING,
+        )
+        map.put(
+            AspectKErrors.AROUND_REPLACE_SLOT_UNRESOLVED,
+            "@Around: {0}(...) ignored — slot identifier must be a compile-time constant Int index or String name.",
             CommonRenderers.STRING,
         )
     }


### PR DESCRIPTION
## Summary

`AroundAdviceWeaver` had three silent bail-out paths that left users wondering why their `@Around` advice stopped intercepting:

1. Advice body shape didn't match `interceptableAdvice<R> { ... }` — `findAdviceLambda` returned `null` and weaving was skipped without any diagnostic.
2. Matched target body wasn't a single `return <expr>` — `singleReturnValue` returned `null` and weaving was skipped.
3. `AroundScope.replaceValueParameter(slot, value)` / `replaceContextParameter` called with a non-const slot — the call was left as the runtime-throwing `aspectk-core` stub; the user had no signal at compile time.

This PR surfaces all three as warnings via `pluginContext.diagnosticReporter`. Compilation still succeeds (warnings, not errors), but the user gets actionable feedback.

## New diagnostics

| Factory | Fired when | Argument |
|---|---|---|
| `AROUND_NOT_WOVEN` | Malformed advice body, or matched target's body isn't a single-return expression | reason string with hint |
| `AROUND_REPLACE_SLOT_UNRESOLVED` | `replace*` call's slot identifier isn't a compile-time `Int` or `String` constant | the `replace*` function name (e.g. `replaceValueParameter`) |
| `AROUND_UNSUPPORTED_BINDING` (existing) | Catch-all binding (`@ValueParameters` / `@ContextParameters`) on `@Around` | annotation name (unchanged) |

`AROUND_NOT_WOVEN` and `AROUND_UNSUPPORTED_BINDING` share the same rendered message shape (`"@Around advice not woven: {0}"`), so user-facing output is consistent regardless of which path bailed. They're separate factory names so future code paths can distinguish them.

## Implementation

- Added `AROUND_NOT_WOVEN` and `AROUND_REPLACE_SLOT_UNRESOLVED` to `AspectKErrors`.
- Replaced three silent `return false` / `return null` paths with explicit `.report(...) ; return …` blocks in `AroundAdviceWeaver`.
- Plumbed `pluginContext` into `AroundSubstitutionTransformer` so the per-call-site `AROUND_REPLACE_SLOT_UNRESOLVED` diagnostic can attach to the offending `replace*` expression.
- Updated the KDoc on `replaceCallTargetSlot` / `resolveSlotByConstArg` to reflect the new behavior (the old comment pointing at "task #26" is no longer accurate).

## Test plan

- [x] `./gradlew :aspectk-compiler:test --rerun-tasks` green locally — existing box / diagnostic tests still pass (no regressions; only added warnings on previously silent paths).
- [ ] CI on `feat/v1` green after rebase.

## Note on IR-time diagnostic testing

There's no diagnostic-test framework wired up for IR-emitted diagnostics in this repo (`AbstractAspectKDiagnosticTest` only runs FIR). The new warnings work at runtime — verified by code inspection and by the fact that compilation succeeds — but assertions are deferred to a follow-up that adds IR-diagnostic test plumbing. Adding `// MUTE_IR_DIAGNOSTICS` or similar would be the entry point.
