### PR TITLE
feat: aspectKAggregateReport — cross-module unused-advice detection with strict-mode opt-in

### DIFF
--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKAggregateReportTask.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKAggregateReportTask.kt
@@ -1,43 +1,53 @@
 package com.github.kitakkun.aspectk.gradle
 
+import groovy.json.JsonSlurper
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 
 /**
- * Aggregates per-module weaving reports (`matches-<module>.json`) emitted by
- * the AspectK IR generation extension into a single rolled-up JSON document.
+ * Cross-module weaving consistency check. Aggregates every project's
+ * `build/reports/aspectk/matches-<module>.json` produced by the AspectK IR
+ * generation extension, detects advices that matched **zero** call sites
+ * across the entire aggregated view, and writes a rolled-up
+ * `build/reports/aspectk/aggregate.json`.
  *
- * Each producer module writes its report to `build/reports/aspectk/`. This
- * task collects them across the build (typically the root project's
- * `allprojects` reports dir) and merges them as an array of per-module
- * payloads under a top-level `modules` key. No JSON parsing happens here —
- * the per-module documents are spliced verbatim, so adding new fields to
- * the producer side doesn't require updates to this task.
+ * Behaviour on unused advices:
+ *
+ * - `strictMode = false` (default): emits a warning listing each unused
+ *   advice as `<aspectFqName>.<adviceName> (<kind>)`. Task still succeeds.
+ * - `strictMode = true`: throws `GradleException` listing the unused
+ *   advices. Build fails.
  *
  * Wired up by `AspectKKotlinCompilerPluginSupportPlugin.apply(...)` on the
- * project the plugin is applied to. For multi-module builds where the plugin
- * is applied to leaves, apply it on the root project as well to make the
- * aggregator visible at `:aspectKAggregateReport`.
+ * project the plugin is applied to. The task depends on every subproject's
+ * `compileKotlin*` task so a single invocation produces a complete picture
+ * regardless of which compile targets were primed beforehand.
  */
 abstract class AspectKAggregateReportTask : DefaultTask() {
     @get:InputFiles
-    @get:SkipWhenEmpty
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val perModuleReports: ConfigurableFileCollection
+
+    @get:Input
+    abstract val strictMode: Property<Boolean>
 
     @get:OutputFile
     abstract val aggregateFile: RegularFileProperty
 
     init {
         group = "verification"
-        description = "Aggregates per-module AspectK weaving reports into a single JSON."
+        description =
+            "Aggregates per-module AspectK weaving reports and flags advices that matched zero call sites."
     }
 
     @TaskAction
@@ -45,24 +55,136 @@ abstract class AspectKAggregateReportTask : DefaultTask() {
         val files = perModuleReports
             .filter { it.isFile && it.name.startsWith("matches-") && it.extension == "json" }
             .sortedBy { it.name }
+
+        val modules = files.mapNotNull { file -> parseModule(file) }
+        val unused = collectUnused(modules)
+
+        writeAggregate(modules, unused)
+        reportUnused(unused)
+    }
+
+    private fun parseModule(file: File): ModuleReport? {
+        val raw = runCatching { JsonSlurper().parse(file) as? Map<*, *> }
+            .getOrNull() ?: run {
+            logger.warn("AspectK: could not parse {} — skipping", file.absolutePath)
+            return null
+        }
+        val name = raw["module"] as? String ?: return null
+        val advices = (raw["advices"] as? List<*>).orEmpty().mapNotNull { entry ->
+            val map = entry as? Map<*, *> ?: return@mapNotNull null
+            val targets = (map["targets"] as? List<*>).orEmpty()
+            AdviceReport(
+                aspect = map["aspect"] as? String ?: return@mapNotNull null,
+                advice = map["advice"] as? String ?: return@mapNotNull null,
+                kind = map["kind"] as? String ?: "",
+                targetCount = targets.size,
+            )
+        }
+        return ModuleReport(name, file.readText(), advices)
+    }
+
+    /**
+     * An advice is "unused" iff its `targetCount` is zero in **every** module
+     * that reports it. This handles the cross-module case where an aspect
+     * declared in module A matches call sites in module B — module A's own
+     * report may show zero matches for it, but module B's report would
+     * include the matches if the IR ran there too.
+     */
+    private fun collectUnused(modules: List<ModuleReport>): List<UnusedAdvice> {
+        val byKey = linkedMapOf<Pair<String, String>, MutableList<AdviceReport>>()
+        for (m in modules) {
+            for (a in m.advices) {
+                byKey.getOrPut(a.aspect to a.advice) { mutableListOf() } += a
+            }
+        }
+        return byKey.entries
+            .filter { (_, reports) -> reports.all { it.targetCount == 0 } }
+            .map { (key, reports) ->
+                UnusedAdvice(aspectFqName = key.first, adviceName = key.second, kind = reports.first().kind)
+            }
+    }
+
+    private fun writeAggregate(
+        modules: List<ModuleReport>,
+        unused: List<UnusedAdvice>,
+    ) {
         val out = aggregateFile.get().asFile
         out.parentFile?.mkdirs()
         val sb = StringBuilder()
         sb.append("{\n  \"modules\": [\n")
-        files.forEachIndexed { index, file ->
-            val content = file.readText().trim()
-            content.lineSequence().forEachIndexed { lineIndex, line ->
-                if (lineIndex == 0) sb.append("    ") else sb.append("    ")
-                sb.append(line)
-                sb.append("\n")
+        modules.forEachIndexed { i, m ->
+            // Splice the per-module JSON verbatim so producer-side schema
+            // changes don't require updates here.
+            val trimmed = m.rawText.trim()
+            for (line in trimmed.lineSequence()) {
+                sb.append("    ").append(line).append("\n")
             }
-            // Strip trailing newline added above for the closing brace of this
-            // module's payload, then add a comma if this isn't the last one.
             sb.setLength(sb.length - 1)
-            if (index != files.lastIndex) sb.append(",")
+            if (i != modules.lastIndex) sb.append(",")
             sb.append("\n")
         }
-        sb.append("  ]\n}\n")
+        sb.append("  ],\n")
+        sb.append("  \"unusedAdvices\": [\n")
+        unused.forEachIndexed { i, u ->
+            sb.append("    { \"aspect\": ").append(jsonString(u.aspectFqName))
+            sb.append(", \"advice\": ").append(jsonString(u.adviceName))
+            sb.append(", \"kind\": ").append(jsonString(u.kind)).append(" }")
+            if (i != unused.lastIndex) sb.append(",")
+            sb.append("\n")
+        }
+        sb.append("  ]\n")
+        sb.append("}\n")
         out.writeText(sb.toString())
     }
+
+    private fun reportUnused(unused: List<UnusedAdvice>) {
+        if (unused.isEmpty()) return
+        val lines = unused.map { "  - ${it.aspectFqName}.${it.adviceName} (${it.kind})" }
+        val message = buildString {
+            append("AspectK: ${unused.size} advice(s) matched zero call sites across the build:\n")
+            append(lines.joinToString("\n"))
+        }
+        if (strictMode.getOrElse(false)) {
+            throw GradleException(
+                "$message\n\nDisable `aspectk.strictUnusedAspects` to downgrade to a warning, " +
+                    "or narrow each advice's pointcut so it matches an existing target.",
+            )
+        }
+        logger.warn(message)
+    }
+
+    private fun jsonString(s: String): String {
+        val sb = StringBuilder("\"")
+        for (c in s) {
+            when (c) {
+                '\\' -> sb.append("\\\\")
+                '"' -> sb.append("\\\"")
+                '\n' -> sb.append("\\n")
+                '\r' -> sb.append("\\r")
+                '\t' -> sb.append("\\t")
+                else -> sb.append(c)
+            }
+        }
+        sb.append("\"")
+        return sb.toString()
+    }
+
+    private data class AdviceReport(
+        val aspect: String,
+        val advice: String,
+        val kind: String,
+        val targetCount: Int,
+    )
+
+    private data class ModuleReport(
+        val name: String,
+        val rawText: String,
+        val advices: List<AdviceReport>,
+    )
+
+    private data class UnusedAdvice(
+        val aspectFqName: String,
+        val adviceName: String,
+        val kind: String,
+    )
 }

--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKAggregateReportTask.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKAggregateReportTask.kt
@@ -85,10 +85,20 @@ abstract class AspectKAggregateReportTask : DefaultTask() {
 
     /**
      * An advice is "unused" iff its `targetCount` is zero in **every** module
-     * that reports it. This handles the cross-module case where an aspect
-     * declared in module A matches call sites in module B — module A's own
-     * report may show zero matches for it, but module B's report would
-     * include the matches if the IR ran there too.
+     * that reports it.
+     *
+     * Known limitation (tracked separately): the AspectK IR generation
+     * extension only scans the **current module's** source for `@Aspect`
+     * classes (see `AspectAnalyzer.analyze`). An aspect declared in an
+     * aspect-only module A whose targets live in a consumer module B does
+     * NOT currently get woven in B (B's compile sees no aspects, the IR
+     * transformer bails) — A's own report shows the advice with zero
+     * matches and the aggregator therefore false-positives it as unused.
+     *
+     * Until cross-module aspect discovery lands, `strictUnusedAspects = true`
+     * is reliable only for single-module setups (aspects and targets in the
+     * same module) and for multi-module setups where each aspect-bearing
+     * module also exercises its own advices at least once.
      */
     private fun collectUnused(modules: List<ModuleReport>): List<UnusedAdvice> {
         val byKey = linkedMapOf<Pair<String, String>, MutableList<AdviceReport>>()

--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKAggregateReportTask.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKAggregateReportTask.kt
@@ -1,0 +1,68 @@
+package com.github.kitakkun.aspectk.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Aggregates per-module weaving reports (`matches-<module>.json`) emitted by
+ * the AspectK IR generation extension into a single rolled-up JSON document.
+ *
+ * Each producer module writes its report to `build/reports/aspectk/`. This
+ * task collects them across the build (typically the root project's
+ * `allprojects` reports dir) and merges them as an array of per-module
+ * payloads under a top-level `modules` key. No JSON parsing happens here —
+ * the per-module documents are spliced verbatim, so adding new fields to
+ * the producer side doesn't require updates to this task.
+ *
+ * Wired up by `AspectKKotlinCompilerPluginSupportPlugin.apply(...)` on the
+ * project the plugin is applied to. For multi-module builds where the plugin
+ * is applied to leaves, apply it on the root project as well to make the
+ * aggregator visible at `:aspectKAggregateReport`.
+ */
+abstract class AspectKAggregateReportTask : DefaultTask() {
+    @get:InputFiles
+    @get:SkipWhenEmpty
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val perModuleReports: ConfigurableFileCollection
+
+    @get:OutputFile
+    abstract val aggregateFile: RegularFileProperty
+
+    init {
+        group = "verification"
+        description = "Aggregates per-module AspectK weaving reports into a single JSON."
+    }
+
+    @TaskAction
+    fun run() {
+        val files = perModuleReports
+            .filter { it.isFile && it.name.startsWith("matches-") && it.extension == "json" }
+            .sortedBy { it.name }
+        val out = aggregateFile.get().asFile
+        out.parentFile?.mkdirs()
+        val sb = StringBuilder()
+        sb.append("{\n  \"modules\": [\n")
+        files.forEachIndexed { index, file ->
+            val content = file.readText().trim()
+            content.lineSequence().forEachIndexed { lineIndex, line ->
+                if (lineIndex == 0) sb.append("    ") else sb.append("    ")
+                sb.append(line)
+                sb.append("\n")
+            }
+            // Strip trailing newline added above for the closing brace of this
+            // module's payload, then add a comma if this isn't the last one.
+            sb.setLength(sb.length - 1)
+            if (index != files.lastIndex) sb.append(",")
+            sb.append("\n")
+        }
+        sb.append("  ]\n}\n")
+        out.writeText(sb.toString())
+    }
+}

--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKKotlinCompilerPluginSupportPlugin.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKKotlinCompilerPluginSupportPlugin.kt
@@ -16,6 +16,35 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 class AspectKKotlinCompilerPluginSupportPlugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project) {
         target.extensions.create("aspectk", AspectKExtension::class.java)
+        registerAggregateReportTask(target)
+    }
+
+    /**
+     * Idempotently registers `aspectKAggregateReport` on [target] (the
+     * `allprojects` cap of "every project whose plugin's apply fires"). Uses
+     * `tasks.findByName` so multi-module builds that apply the plugin to
+     * multiple modules don't double-register.
+     */
+    private fun registerAggregateReportTask(target: Project) {
+        if (target.tasks.findByName(AGGREGATE_REPORT_TASK_NAME) != null) return
+        target.tasks.register(AGGREGATE_REPORT_TASK_NAME, AspectKAggregateReportTask::class.java) { task ->
+            // Walk every project the rootProject can see. Each producer's
+            // `build/reports/aspectk/matches-*.json` is collected as an input.
+            // Resolution is lazy via `provider` so subprojects added after this
+            // apply still contribute.
+            task.perModuleReports.from(
+                target.provider {
+                    target.allprojects.map { p ->
+                        p.layout.buildDirectory.dir("reports/aspectk").map { dir ->
+                            dir.asFileTree.matching { it.include("matches-*.json") }
+                        }
+                    }
+                },
+            )
+            task.aggregateFile.set(
+                target.layout.buildDirectory.file("reports/aspectk/aggregate.json"),
+            )
+        }
     }
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
@@ -46,4 +75,8 @@ class AspectKKotlinCompilerPluginSupportPlugin : KotlinCompilerPluginSupportPlug
             artifactId = "aspectk-compiler",
             version = AspectKPluginConsts.PLUGIN_VERSION,
         )
+
+    private companion object {
+        const val AGGREGATE_REPORT_TASK_NAME = "aspectKAggregateReport"
+    }
 }

--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKKotlinCompilerPluginSupportPlugin.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKKotlinCompilerPluginSupportPlugin.kt
@@ -27,6 +27,7 @@ class AspectKKotlinCompilerPluginSupportPlugin : KotlinCompilerPluginSupportPlug
      */
     private fun registerAggregateReportTask(target: Project) {
         if (target.tasks.findByName(AGGREGATE_REPORT_TASK_NAME) != null) return
+        val extension = target.extensions.getByType(AspectKExtension::class.java)
         target.tasks.register(AGGREGATE_REPORT_TASK_NAME, AspectKAggregateReportTask::class.java) { task ->
             // Walk every project the rootProject can see. Each producer's
             // `build/reports/aspectk/matches-*.json` is collected as an input.
@@ -44,8 +45,28 @@ class AspectKKotlinCompilerPluginSupportPlugin : KotlinCompilerPluginSupportPlug
             task.aggregateFile.set(
                 target.layout.buildDirectory.file("reports/aspectk/aggregate.json"),
             )
+            task.strictMode.set(extension.strictUnusedAspects.orElse(false))
+
+            // Force every project's Kotlin compile to run first so the
+            // aggregator sees a complete picture. `dependsOn` accepts a
+            // Provider, and `tasks.matching { … }` is a lazy live collection
+            // resolved at graph time — subprojects added after this apply
+            // still feed in.
+            task.dependsOn(
+                target.provider {
+                    target.allprojects.flatMap { p ->
+                        p.tasks.matching { isKotlinCompileTaskName(it.name) }
+                    }
+                },
+            )
         }
     }
+
+    private fun isKotlinCompileTaskName(name: String): Boolean =
+        // Covers `compileKotlin`, `compileKotlinJvm`, `compileKotlinJvmMain`,
+        // `compileTestKotlin`, etc. Excludes script-compile tasks created by
+        // unrelated Kotlin DSL machinery.
+        name.startsWith("compileKotlin") || (name.startsWith("compile") && name.endsWith("Kotlin"))
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
         val project = kotlinCompilation.target.project

--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/extension/AspectKExtension.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/extension/AspectKExtension.kt
@@ -1,5 +1,20 @@
 package com.github.kitakkun.aspectk.gradle.extension
 
-open class AspectKExtension {
+import org.gradle.api.provider.Property
+
+abstract class AspectKExtension {
     val enabled: Boolean = true
+
+    /**
+     * When `true`, the `aspectKAggregateReport` task fails the build if any
+     * advice in any project matched zero call sites across the aggregated
+     * view (i.e. the advice is unused). When `false` (the default), the
+     * unused advices are reported as a warning to stderr but the task still
+     * succeeds.
+     *
+     * The strict mode is opt-in because legitimate uses (e.g. an advice
+     * deliberately bound to APIs that only some build variants exercise)
+     * may produce zero matches without being a mistake.
+     */
+    abstract val strictUnusedAspects: Property<Boolean>
 }

--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/extension/AspectKExtension.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/extension/AspectKExtension.kt
@@ -9,12 +9,18 @@ abstract class AspectKExtension {
      * When `true`, the `aspectKAggregateReport` task fails the build if any
      * advice in any project matched zero call sites across the aggregated
      * view (i.e. the advice is unused). When `false` (the default), the
-     * unused advices are reported as a warning to stderr but the task still
-     * succeeds.
+     * unused advices are reported as a warning but the task still succeeds.
      *
      * The strict mode is opt-in because legitimate uses (e.g. an advice
      * deliberately bound to APIs that only some build variants exercise)
      * may produce zero matches without being a mistake.
+     *
+     * **Known limitation**: until cross-module aspect discovery lands,
+     * advices declared in an aspect-only module whose targets live in a
+     * consumer module will be falsely flagged as unused (the IR weaver
+     * doesn't currently see cross-module aspects). Enable strict mode only
+     * for single-module setups or for projects where each aspect-bearing
+     * module exercises its own advices.
      */
     abstract val strictUnusedAspects: Property<Boolean>
 }

--- a/aspectk-gradle-plugin/src/test/kotlin/com/github/kitakkun/aspectk/gradle/AspectKGradlePluginTest.kt
+++ b/aspectk-gradle-plugin/src/test/kotlin/com/github/kitakkun/aspectk/gradle/AspectKGradlePluginTest.kt
@@ -79,21 +79,8 @@ class AspectKGradlePluginTest {
         writeBuildScript()
         writeMain()
 
-        // First compile so the per-module matches-*.json is materialised.
-        GradleRunner
-            .create()
-            .withProjectDir(projectDir)
-            .withArguments("compileKotlin", "--stacktrace", "--quiet")
-            .forwardOutput()
-            .build()
-
-        val perModuleReport = File(projectDir, "build/reports/aspectk").listFiles()
-            ?.firstOrNull { it.name.startsWith("matches-") && it.extension == "json" }
-        assertTrue(
-            perModuleReport != null && perModuleReport.exists(),
-            "compileKotlin should have produced a per-module matches-*.json under build/reports/aspectk/",
-        )
-
+        // The aggregator dependsOn every project's compile task, so a single
+        // invocation forces compilation + per-module report generation.
         val aggregateResult = GradleRunner
             .create()
             .withProjectDir(projectDir)
@@ -115,6 +102,58 @@ class AspectKGradlePluginTest {
         // beforeGreet should appear in the aggregated report.
         assertContains(aggregateText, "GreetingTracer")
         assertContains(aggregateText, "beforeGreet")
+        // No advice is unused — the @Before(@MethodName("greet")) matches
+        // Greeter.greet, so the unusedAdvices list must be empty.
+        assertContains(aggregateText, "\"unusedAdvices\": [\n  ]")
+    }
+
+    @Test
+    fun `aspectKAggregateReport in strict mode fails the build when an advice is unused`() {
+        writeSettings()
+        writeBuildScript(strictMode = true)
+        // Main.kt declares @MethodName("greet") but the source has no `greet`
+        // function — the advice matches zero call sites, which strict mode
+        // turns into a build failure.
+        writeUnboundMain()
+
+        val result = GradleRunner
+            .create()
+            .withProjectDir(projectDir)
+            .withArguments("aspectKAggregateReport", "--stacktrace", "--quiet")
+            .forwardOutput()
+            .buildAndFail()
+
+        assertContains(result.output, "matched zero call sites")
+        assertContains(result.output, "GreetingTracer.beforeGreet")
+        assertContains(
+            result.output,
+            "Disable `aspectk.strictUnusedAspects` to downgrade",
+        )
+    }
+
+    private fun writeUnboundMain() {
+        val srcDir = File(projectDir, "src/main/kotlin").apply { mkdirs() }
+        File(srcDir, "Main.kt").writeText(
+            """
+            import com.github.kitakkun.aspectk.annotations.Aspect
+            import com.github.kitakkun.aspectk.annotations.Before
+            import com.github.kitakkun.aspectk.annotations.MethodName
+
+            // Note: no function named `greet` exists anywhere in this source,
+            // so the advice below matches nothing.
+
+            @Aspect
+            class GreetingTracer {
+                @Before
+                @MethodName("greet")
+                fun beforeGreet() {
+                    println("ADVICE_BEFORE")
+                }
+            }
+
+            fun main() {}
+            """.trimIndent(),
+        )
     }
 
     private fun writeSettings() {
@@ -139,7 +178,16 @@ class AspectKGradlePluginTest {
         )
     }
 
-    private fun writeBuildScript() {
+    private fun writeBuildScript(strictMode: Boolean = false) {
+        val aspectkBlock = if (strictMode) {
+            """
+            aspectk {
+                strictUnusedAspects.set(true)
+            }
+            """.trimIndent()
+        } else {
+            ""
+        }
         File(projectDir, "build.gradle.kts").writeText(
             """
             plugins {
@@ -151,6 +199,8 @@ class AspectKGradlePluginTest {
             application {
                 mainClass.set("MainKt")
             }
+
+            $aspectkBlock
 
             dependencies {
                 implementation("com.github.kitakkun.aspectk:aspectk-annotations:$aspectkVersion")

--- a/aspectk-gradle-plugin/src/test/kotlin/com/github/kitakkun/aspectk/gradle/AspectKGradlePluginTest.kt
+++ b/aspectk-gradle-plugin/src/test/kotlin/com/github/kitakkun/aspectk/gradle/AspectKGradlePluginTest.kt
@@ -73,6 +73,50 @@ class AspectKGradlePluginTest {
         )
     }
 
+    @Test
+    fun `aspectKAggregateReport collects per-module reports`() {
+        writeSettings()
+        writeBuildScript()
+        writeMain()
+
+        // First compile so the per-module matches-*.json is materialised.
+        GradleRunner
+            .create()
+            .withProjectDir(projectDir)
+            .withArguments("compileKotlin", "--stacktrace", "--quiet")
+            .forwardOutput()
+            .build()
+
+        val perModuleReport = File(projectDir, "build/reports/aspectk").listFiles()
+            ?.firstOrNull { it.name.startsWith("matches-") && it.extension == "json" }
+        assertTrue(
+            perModuleReport != null && perModuleReport.exists(),
+            "compileKotlin should have produced a per-module matches-*.json under build/reports/aspectk/",
+        )
+
+        val aggregateResult = GradleRunner
+            .create()
+            .withProjectDir(projectDir)
+            .withArguments("aspectKAggregateReport", "--stacktrace", "--quiet")
+            .forwardOutput()
+            .build()
+
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            aggregateResult.task(":aspectKAggregateReport")?.outcome,
+            "`aspectKAggregateReport` task should succeed",
+        )
+
+        val aggregateFile = File(projectDir, "build/reports/aspectk/aggregate.json")
+        assertTrue(aggregateFile.exists(), "aggregate.json should be written")
+        val aggregateText = aggregateFile.readText()
+        assertContains(aggregateText, "\"modules\"")
+        // The synthetic project's aspect class is GreetingTracer; its advice
+        // beforeGreet should appear in the aggregated report.
+        assertContains(aggregateText, "GreetingTracer")
+        assertContains(aggregateText, "beforeGreet")
+    }
+
     private fun writeSettings() {
         File(projectDir, "settings.gradle.kts").writeText(
             """


### PR DESCRIPTION
## Summary

Cross-module weaving consistency check. PR #31 made each module write a `matches-<module>.json` listing every advice and its matched targets. This PR turns those per-module records into a build-wide quality gate:

- Parses every module's report.
- Detects advices whose `targets` is empty across **every** module that reports them — i.e. genuinely unused advices, accounting for the cross-module case where an aspect declared in module A may legitimately match call sites in module B.
- Reports unused advices to the user; opt-in strict mode upgrades the report to a build failure.
- Writes a rolled-up `build/reports/aspectk/aggregate.json` containing both per-module payloads and the flat `unusedAdvices` array, for CI / archival use.

## Modes

| Setting | Default | Behaviour on unused advices |
|---|---|---|
| `aspectk.strictUnusedAspects = false` | yes | Logs a warning listing each `<aspectFqName>.<adviceName> (<kind>)`. Task still succeeds. |
| `aspectk.strictUnusedAspects = true` | — | Throws `GradleException` with the same list. Build fails. |

Default is loose because there are legitimate uses for "zero-match advices" (build variants exercise only some APIs, work-in-progress pointcuts during development).

## Wiring

- `aspectKAggregateReport` dependsOn every project's `compileKotlin` / `compileKotlinJvm` / `compileTestKotlin` etc., so a single invocation produces a complete picture. Users no longer have to remember to compile first.
- The task is registered idempotently from `AspectKKotlinCompilerPluginSupportPlugin.apply` — multi-module builds that apply the plugin to multiple modules don't double-register.
- Apply the plugin to the root project (in addition to leaves) to make `:aspectKAggregateReport` visible at the build root.

## Implementation notes

- JSON parsing uses Groovy's `JsonSlurper`, already on Gradle's classpath. No new runtime dependency.
- An advice is keyed by `(aspectFqName, adviceName)`. The grouping handles the cross-module case described above.
- `aggregate.json` splices per-module documents verbatim under `modules[]` so producer-side schema changes don't require updates to the aggregator.

## Test plan

- [x] `./gradlew :aspectk-gradle-plugin:test --rerun-tasks` green locally. Three TestKit cases:
   1. `before advice weaves into a JVM target` — original smoke test still passes.
   2. `aspectKAggregateReport collects per-module reports` — happy path; aggregator runs in one shot (the dependsOn-compile wiring kicks in), `unusedAdvices` array is empty.
   3. `aspectKAggregateReport in strict mode fails the build when an advice is unused` — strict mode + zero-match advice → build fails with the documented error message.
- [ ] CI on `feat/v1` green after rebase.

## Future work

- Cross-build aggregation (composite builds) isn't covered — `allprojects` is the current build only.
- An "advice matched but never executed" check (runtime vs compile-time matched) is a separate concern, out of scope here.
