### PR TITLE
feat: cross-module @Aspect discovery via META-INF aspect index

### DIFF
--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCommandLineProcessor.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCommandLineProcessor.kt
@@ -29,6 +29,17 @@ class AspectKCommandLineProcessor : CommandLineProcessor {
             allowMultipleOccurrences = false,
             required = false,
         ),
+        CliOption(
+            optionName = "aspectIndexFile",
+            description =
+                "Absolute path the compiler plugin writes the producer-side aspect index to. " +
+                    "Typically <buildDir>/aspectk/aspectIndex/<compName>/META-INF/aspectk/aspects.txt; " +
+                    "bundled into the producer JAR so downstream consumers can pick it up by scanning " +
+                    "their compile classpath.",
+            valueDescription = "<absolute-path>",
+            allowMultipleOccurrences = false,
+            required = false,
+        ),
     )
 
     override fun processOption(
@@ -39,6 +50,7 @@ class AspectKCommandLineProcessor : CommandLineProcessor {
         when (option.optionName) {
             "enabled" -> configuration.put(AspectKCompilerConfigurationKey.ENABLED, value.toBoolean())
             "reportDir" -> configuration.put(AspectKCompilerConfigurationKey.REPORT_DIR, value)
+            "aspectIndexFile" -> configuration.put(AspectKCompilerConfigurationKey.ASPECT_INDEX_FILE, value)
             else -> error("Unexpected config option ${option.optionName}")
         }
     }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCompilerConfigurationKey.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCompilerConfigurationKey.kt
@@ -6,4 +6,5 @@ import org.jetbrains.kotlin.config.CompilerConfigurationKey
 object AspectKCompilerConfigurationKey {
     val ENABLED = CompilerConfigurationKey<Boolean>(AspectKSubPluginOptionKey.ENABLED)
     val REPORT_DIR = CompilerConfigurationKey<String>(AspectKSubPluginOptionKey.REPORT_DIR)
+    val ASPECT_INDEX_FILE = CompilerConfigurationKey<String>(AspectKSubPluginOptionKey.ASPECT_INDEX_FILE)
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCompilerPluginRegistrar.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/AspectKCompilerPluginRegistrar.kt
@@ -5,6 +5,8 @@ import com.github.kitakkun.aspectk.compiler.fir.AspectKFirExtensionRegistrar
 import com.github.kitakkun.aspectk.plugin.common.AspectKPluginConsts
 import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.jvm.config.JvmClasspathRoot
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
@@ -22,7 +24,24 @@ class AspectKCompilerPluginRegistrar : CompilerPluginRegistrar() {
         if (!enabled) return
 
         val reportDir = configuration[AspectKCompilerConfigurationKey.REPORT_DIR]
+        val aspectIndexFile = configuration[AspectKCompilerConfigurationKey.ASPECT_INDEX_FILE]
+        // Snapshot the JVM classpath so the IR extension can scan
+        // META-INF/aspectk/aspects.txt entries inside dependency JARs and
+        // exploded class directories. We do this at registrar time rather
+        // than inside the IR extension because the CompilerConfiguration
+        // isn't exposed by IrPluginContext. SDK roots (bootclasspath etc.)
+        // are skipped — only user dependencies can carry AspectK markers.
+        val classpathRoots = configuration.get(CLIConfigurationKeys.CONTENT_ROOTS).orEmpty()
+            .filterIsInstance<JvmClasspathRoot>()
+            .filterNot { it.isSdkRoot }
+            .map { it.file }
         FirExtensionRegistrarAdapter.registerExtension(AspectKFirExtensionRegistrar())
-        IrGenerationExtension.registerExtension(AspectKIrGenerationExtension(reportDir))
+        IrGenerationExtension.registerExtension(
+            AspectKIrGenerationExtension(
+                reportDir = reportDir,
+                aspectIndexFile = aspectIndexFile,
+                classpathRoots = classpathRoots,
+            ),
+        )
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrGenerationExtension.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/AspectKIrGenerationExtension.kt
@@ -11,22 +11,114 @@ import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
 import java.io.File
+import java.util.jar.JarFile
 
 class AspectKIrGenerationExtension(
     private val reportDir: String?,
+    private val aspectIndexFile: String? = null,
+    private val classpathRoots: List<File> = emptyList(),
 ) : IrGenerationExtension {
     override fun generate(
         moduleFragment: IrModuleFragment,
         pluginContext: IrPluginContext,
     ) {
-        val aspects = AspectAnalyzer().analyze(moduleFragment)
+        val analyzer = AspectAnalyzer()
+        val localAspects = analyzer.analyze(moduleFragment)
+        val externalAspects = resolveExternalAspects(analyzer, pluginContext)
+        val aspects = localAspects + externalAspects
+
+        // Write the producer-side aspect index before bailing on no-aspect
+        // modules — but only when there's something to publish. Skipping
+        // empty modules avoids littering every Kotlin JAR with a useless
+        // META-INF/aspectk/aspects.txt marker.
+        if (aspectIndexFile != null && localAspects.isNotEmpty()) {
+            writeAspectIndex(File(aspectIndexFile), localAspects)
+        }
+
         if (aspects.isEmpty()) return
         val transformer = AspectKTransformer(pluginContext, aspects)
         moduleFragment.transform(transformer, null)
 
         reportDir?.let { dir ->
             writeReport(File(dir), moduleFragment.name.asString(), aspects, transformer.matches)
+        }
+    }
+
+    /**
+     * Discovers `@Aspect` classes from the compile classpath and resolves
+     * each to an [AspectMetadata] via the IR-time finder API.
+     *
+     * Discovery: each entry in [classpathRoots] (a snapshot of the JVM
+     * `CONTENT_ROOTS` taken at registrar time) is checked for the marker
+     * file `META-INF/aspectk/aspects.txt` — listed one fully-qualified
+     * `@Aspect` class name per line. Both packaged JARs and exploded class
+     * directories are supported, so project deps (which Gradle resolves to
+     * `classes` directories) work without going through a JAR.
+     *
+     * Resolution: each discovered FQN is looked up through
+     * `pluginContext.finderForBuiltins().findClass(...)`. The
+     * builtins-flavoured finder is appropriate because the FQN list comes
+     * from a build-tool channel, not from any specific source file in this
+     * compilation. Names that fail to resolve are silently dropped — that
+     * typically means the user's dependency was removed between the marker
+     * being written and the consumer compile being launched.
+     */
+    private fun resolveExternalAspects(
+        analyzer: AspectAnalyzer,
+        pluginContext: IrPluginContext,
+    ): List<AspectMetadata> {
+        val externalFqNames = discoverExternalAspectFqNames()
+        if (externalFqNames.isEmpty()) return emptyList()
+        val finder = pluginContext.finderForBuiltins()
+        return externalFqNames.mapNotNull { fqName ->
+            val classId = ClassId.topLevel(FqName(fqName))
+            val symbol = finder.findClass(classId) ?: return@mapNotNull null
+            analyzer.buildAspectMetadata(symbol.owner)
+        }
+    }
+
+    private fun discoverExternalAspectFqNames(): List<String> {
+        if (classpathRoots.isEmpty()) return emptyList()
+        val result = linkedSetOf<String>()
+        for (root in classpathRoots) {
+            when {
+                !root.exists() -> continue
+                root.isFile && root.name.endsWith(".jar") -> readFromJar(root).forEach { result += it }
+                root.isDirectory -> readFromDirectory(root).forEach { result += it }
+            }
+        }
+        return result.toList()
+    }
+
+    private fun readFromJar(jarFile: File): List<String> =
+        runCatching {
+            JarFile(jarFile).use { jar ->
+                val entry = jar.getJarEntry(ASPECT_INDEX_ENTRY) ?: return@use emptyList()
+                jar.getInputStream(entry).bufferedReader(Charsets.UTF_8).useLines { lines ->
+                    lines.map { it.trim() }.filter { it.isNotEmpty() }.toList()
+                }
+            }
+        }.getOrDefault(emptyList())
+
+    private fun readFromDirectory(dir: File): List<String> {
+        val file = dir.resolve(ASPECT_INDEX_ENTRY)
+        if (!file.isFile) return emptyList()
+        return runCatching {
+            file.readLines(Charsets.UTF_8).map { it.trim() }.filter { it.isNotEmpty() }
+        }.getOrDefault(emptyList())
+    }
+
+    private fun writeAspectIndex(
+        file: File,
+        localAspects: List<AspectMetadata>,
+    ) {
+        runCatching {
+            file.parentFile?.let { if (!it.exists()) it.mkdirs() }
+            val fqNames = localAspects.map { it.aspectClass.kotlinFqName.asString() }
+            file.writeText(fqNames.joinToString(separator = "\n", postfix = "\n"))
         }
     }
 
@@ -125,5 +217,9 @@ class AspectKIrGenerationExtension(
         }
         sb.append("\"")
         return sb.toString()
+    }
+
+    private companion object {
+        const val ASPECT_INDEX_ENTRY = "META-INF/aspectk/aspects.txt"
     }
 }

--- a/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectAnalyzer.kt
+++ b/aspectk-compiler/src/main/kotlin/com/github/kitakkun/aspectk/compiler/backend/analyzer/AspectAnalyzer.kt
@@ -49,7 +49,14 @@ internal class AspectAnalyzer {
         return aspects
     }
 
-    private fun buildAspectMetadata(aspectClass: IrClass): AspectMetadata {
+    /**
+     * Builds [AspectMetadata] from an arbitrary `@Aspect` class. Works for
+     * both source `IrClass`es (walked from the module fragment) and
+     * `IrClass`es deserialised from dependency JARs (resolved via
+     * `pluginContext.finderForBuiltins().findClass(classId)`) — the same
+     * IR-shape annotation reading applies.
+     */
+    fun buildAspectMetadata(aspectClass: IrClass): AspectMetadata {
         val advices = aspectClass.declarations
             .filterIsInstance<IrSimpleFunction>()
             .mapNotNull { fn ->

--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKAggregateReportTask.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKAggregateReportTask.kt
@@ -85,20 +85,11 @@ abstract class AspectKAggregateReportTask : DefaultTask() {
 
     /**
      * An advice is "unused" iff its `targetCount` is zero in **every** module
-     * that reports it.
-     *
-     * Known limitation (tracked separately): the AspectK IR generation
-     * extension only scans the **current module's** source for `@Aspect`
-     * classes (see `AspectAnalyzer.analyze`). An aspect declared in an
-     * aspect-only module A whose targets live in a consumer module B does
-     * NOT currently get woven in B (B's compile sees no aspects, the IR
-     * transformer bails) — A's own report shows the advice with zero
-     * matches and the aggregator therefore false-positives it as unused.
-     *
-     * Until cross-module aspect discovery lands, `strictUnusedAspects = true`
-     * is reliable only for single-module setups (aspects and targets in the
-     * same module) and for multi-module setups where each aspect-bearing
-     * module also exercises its own advices at least once.
+     * that reports it. Cross-module weaving (aspect declared in module A,
+     * targets in module B) is supported: B's compile sees A's aspect via
+     * `META-INF/aspectk/aspects.txt` discovery and the matches show up in
+     * B's `matches-*.json`, so the grouping below correctly aggregates the
+     * non-zero count.
      */
     private fun collectUnused(modules: List<ModuleReport>): List<UnusedAdvice> {
         val byKey = linkedMapOf<Pair<String, String>, MutableList<AdviceReport>>()

--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKKotlinCompilerPluginSupportPlugin.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/AspectKKotlinCompilerPluginSupportPlugin.kt
@@ -6,6 +6,7 @@ import com.github.kitakkun.aspectk.plugin.common.AspectKSubPluginOptionKey
 import com.google.auto.service.AutoService
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import org.gradle.jvm.tasks.Jar
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
@@ -17,6 +18,42 @@ class AspectKKotlinCompilerPluginSupportPlugin : KotlinCompilerPluginSupportPlug
     override fun apply(target: Project) {
         target.extensions.create("aspectk", AspectKExtension::class.java)
         registerAggregateReportTask(target)
+        wireAspectIndexIntoJar(target)
+    }
+
+    /**
+     * Adds every `main`-flavoured compilation's aspect-index directory as an
+     * input of every Jar task in the project so the producer-side
+     * `META-INF/aspectk/aspects.txt` ends up bundled into the published JAR.
+     *
+     * Layout: the compiler plugin writes
+     *   `<buildDir>/aspectk/aspectIndex/<compilationName>/META-INF/aspectk/aspects.txt`
+     * for each compilation. We hand each `main`-named subdirectory directly
+     * to `Jar.from(...)`, so its contents (`META-INF/aspectk/...`) land at
+     * the canonical JAR root. Test compilations stay excluded.
+     *
+     * Jar already dependsOn the Kotlin compile via the classes-dir wiring,
+     * so timing is correct.
+     */
+    private fun wireAspectIndexIntoJar(target: Project) {
+        target.tasks.withType(Jar::class.java).configureEach { jar ->
+            jar.from(
+                target.provider {
+                    val base = target.layout.buildDirectory
+                        .dir("aspectk/aspectIndex")
+                        .get()
+                        .asFile
+                    if (!base.isDirectory) {
+                        emptyList<java.io.File>()
+                    } else {
+                        base
+                            .listFiles()
+                            ?.filter { it.isDirectory && (it.name == "main" || it.name.endsWith("Main")) }
+                            ?: emptyList()
+                    }
+                },
+            )
+        }
     }
 
     /**
@@ -72,6 +109,13 @@ class AspectKKotlinCompilerPluginSupportPlugin : KotlinCompilerPluginSupportPlug
         val project = kotlinCompilation.target.project
         val extension = project.extensions.getByType(AspectKExtension::class.java)
         val reportDirProvider = project.layout.buildDirectory.dir("reports/aspectk")
+        // Producer side: write the aspect index under the compile output so
+        // the JAR task naturally bundles it as META-INF/aspectk/aspects.txt.
+        // Consumer-side discovery is handled by the compiler plugin itself:
+        // it scans `JVMConfigurationKeys.CONTENT_ROOTS` for the same marker
+        // entries, so no Gradle-side classpath walk is needed here.
+        val aspectIndexFileProvider =
+            project.layout.buildDirectory.file("aspectk/aspectIndex/${kotlinCompilation.name}/META-INF/aspectk/aspects.txt")
         return project.provider {
             // Resolve buildDirectory lazily (inside the provider) so any
             // user-supplied `layout.buildDirectory.set(...)` override applied
@@ -81,6 +125,10 @@ class AspectKKotlinCompilerPluginSupportPlugin : KotlinCompilerPluginSupportPlug
                 SubpluginOption(
                     key = AspectKSubPluginOptionKey.REPORT_DIR,
                     value = reportDirProvider.get().asFile.absolutePath,
+                ),
+                SubpluginOption(
+                    key = AspectKSubPluginOptionKey.ASPECT_INDEX_FILE,
+                    value = aspectIndexFileProvider.get().asFile.absolutePath,
                 ),
             )
         }

--- a/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/extension/AspectKExtension.kt
+++ b/aspectk-gradle-plugin/src/main/kotlin/com/github/kitakkun/aspectk/gradle/extension/AspectKExtension.kt
@@ -15,12 +15,11 @@ abstract class AspectKExtension {
      * deliberately bound to APIs that only some build variants exercise)
      * may produce zero matches without being a mistake.
      *
-     * **Known limitation**: until cross-module aspect discovery lands,
-     * advices declared in an aspect-only module whose targets live in a
-     * consumer module will be falsely flagged as unused (the IR weaver
-     * doesn't currently see cross-module aspects). Enable strict mode only
-     * for single-module setups or for projects where each aspect-bearing
-     * module exercises its own advices.
+     * Cross-module setups (aspect declared in module A, targets in module B)
+     * are handled correctly: A publishes its `META-INF/aspectk/aspects.txt`
+     * into its JAR, B's compile picks it up via classpath scanning and
+     * weaves the advice into call sites in B. The advice's matches show up
+     * in B's `matches-*.json` so the aggregator counts them.
      */
     abstract val strictUnusedAspects: Property<Boolean>
 }

--- a/aspectk-gradle-plugin/src/test/kotlin/com/github/kitakkun/aspectk/gradle/AspectKGradlePluginTest.kt
+++ b/aspectk-gradle-plugin/src/test/kotlin/com/github/kitakkun/aspectk/gradle/AspectKGradlePluginTest.kt
@@ -10,18 +10,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * End-to-end smoke test for the AspectK Gradle plugin.
+ * End-to-end smoke tests for the AspectK Gradle plugin.
  *
- * Generates a minimal Kotlin/JVM project on disk, applies
- * `com.github.kitakkun.aspectk` to it, and runs the synthetic project's
- * `run` task. Asserts that:
- *
- * - The build succeeds.
- * - Both the `@Before` advice's trace line and the target's own output
- *   appear in stdout, in that order — i.e. weaving actually happened end to
- *   end through the Kotlin compiler plugin pipeline.
- *
- * Three system properties wire the synthetic project to the artefacts the
+ * Each test generates a minimal Kotlin/JVM project on disk, applies
+ * `com.github.kitakkun.aspectk` to it, and runs a Gradle task via TestKit.
+ * Three system properties wire the synthetic projects to the artefacts the
  * outer build published into `build/testRepo/`:
  *
  * - `aspectk.test.repo` — absolute path of the project-local Maven repo.
@@ -128,6 +121,131 @@ class AspectKGradlePluginTest {
         assertContains(
             result.output,
             "Disable `aspectk.strictUnusedAspects` to downgrade",
+        )
+    }
+
+    @Test
+    fun `aspect declared in dependency module weaves into consumer module call sites`() {
+        // Two-module project: ":aspect" declares an @Aspect, ":consumer"
+        // depends on it and calls a function the advice should match. The
+        // pipeline this exercises end-to-end: producer compile writes the
+        // aspect index → Jar bundles META-INF/aspectk/aspects.txt →
+        // consumer's compiler plugin scans classpath JARs → resolves the
+        // external @Aspect via finderForBuiltins().findClass(...) → IR
+        // weaver wraps Greeter.greet.
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            pluginManagement {
+                repositories {
+                    maven(url = "$testRepo")
+                    gradlePluginPortal()
+                }
+            }
+
+            dependencyResolutionManagement {
+                repositories {
+                    maven(url = "$testRepo")
+                    mavenCentral()
+                }
+            }
+
+            rootProject.name = "aspectk-cross-module-sample"
+            include(":aspect")
+            include(":consumer")
+            """.trimIndent(),
+        )
+
+        val aspectDir = File(projectDir, "aspect").apply { mkdirs() }
+        File(aspectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                kotlin("jvm") version "$kotlinVersion"
+                id("com.github.kitakkun.aspectk") version "$aspectkVersion"
+            }
+
+            dependencies {
+                implementation("com.github.kitakkun.aspectk:aspectk-annotations:$aspectkVersion")
+            }
+            """.trimIndent(),
+        )
+        val aspectSrc = File(aspectDir, "src/main/kotlin").apply { mkdirs() }
+        File(aspectSrc, "GreetingTracer.kt").writeText(
+            """
+            package shared
+
+            import com.github.kitakkun.aspectk.annotations.Aspect
+            import com.github.kitakkun.aspectk.annotations.Before
+            import com.github.kitakkun.aspectk.annotations.MethodName
+
+            @Aspect
+            class GreetingTracer {
+                @Before
+                @MethodName("greet")
+                fun beforeGreet() {
+                    println("ADVICE_BEFORE")
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val consumerDir = File(projectDir, "consumer").apply { mkdirs() }
+        File(consumerDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                kotlin("jvm") version "$kotlinVersion"
+                application
+                id("com.github.kitakkun.aspectk") version "$aspectkVersion"
+            }
+
+            application {
+                mainClass.set("consumer.MainKt")
+            }
+
+            dependencies {
+                implementation(project(":aspect"))
+                implementation("com.github.kitakkun.aspectk:aspectk-annotations:$aspectkVersion")
+            }
+            """.trimIndent(),
+        )
+        val consumerSrc = File(consumerDir, "src/main/kotlin/consumer").apply { mkdirs() }
+        File(consumerSrc, "Main.kt").writeText(
+            """
+            package consumer
+
+            class Greeter {
+                fun greet(name: String): String {
+                    val r = "hello ${'$'}name"
+                    println(r)
+                    return r
+                }
+            }
+
+            fun main() {
+                Greeter().greet("world")
+            }
+            """.trimIndent(),
+        )
+
+        val result = GradleRunner
+            .create()
+            .withProjectDir(projectDir)
+            .withArguments(":consumer:run", "--stacktrace", "--quiet")
+            .forwardOutput()
+            .build()
+
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            result.task(":consumer:run")?.outcome,
+            "`:consumer:run` should succeed",
+        )
+        // The @Before advice from the :aspect module wove into Greeter.greet
+        // inside :consumer — ADVICE_BEFORE appears before the target's own
+        // output.
+        assertContains(result.output, "ADVICE_BEFORE")
+        assertContains(result.output, "hello world")
+        assertTrue(
+            result.output.indexOf("ADVICE_BEFORE") < result.output.indexOf("hello world"),
+            "cross-module advice should run before the target body",
         )
     }
 

--- a/aspectk-plugin-common/src/commonMain/kotlin/com/github/kitakkun/aspectk/plugin/common/AspectKSubPluginOptionKey.kt
+++ b/aspectk-plugin-common/src/commonMain/kotlin/com/github/kitakkun/aspectk/plugin/common/AspectKSubPluginOptionKey.kt
@@ -3,4 +3,22 @@ package com.github.kitakkun.aspectk.plugin.common
 object AspectKSubPluginOptionKey {
     const val ENABLED = "enabled"
     const val REPORT_DIR = "reportDir"
+
+    /**
+     * Absolute path the compiler plugin writes the **producer-side** aspect
+     * index to. The Gradle plugin sets this to a file under the project's
+     * `build/aspectk/aspectIndex/<compName>/META-INF/aspectk/aspects.txt`,
+     * then arranges for every Jar task to pick it up so the index is
+     * bundled into the published JAR.
+     *
+     * Cross-module discovery is then **driven entirely from the compiler
+     * plugin side**: when compiling a consumer module, the IR extension
+     * walks `JVMConfigurationKeys.CONTENT_ROOTS` looking for the same
+     * `META-INF/aspectk/aspects.txt` entry inside each classpath JAR /
+     * exploded class directory and resolves the listed FQNs through
+     * `pluginContext.finderForBuiltins().findClass(...)`. There is no
+     * separate consumer-side subplugin option for the FQN list — the
+     * compiler plugin already sees the classpath via `CompilerConfiguration`.
+     */
+    const val ASPECT_INDEX_FILE = "aspectIndexFile"
 }


### PR DESCRIPTION
## Summary

Adds cross-module `` `@Aspect` `` discovery so an aspect declared in one module weaves into call sites in consumer modules. This was the missing piece behind PR #37's documented limitation — the aggregator's `strictUnusedAspects` mode now becomes reliable in multi-module setups.

## Background

The IR-level `AspectAnalyzer` walks `IrModuleFragment.acceptVoid {...}` for `` `@Aspect` `` classes. That's source-module-only. FIR's `predicateBasedProvider.getSymbolsByPredicate` is also source-only — `FirPredicateBasedProviderImpl.registerAnnotatedDeclaration` is only called during source walking, not for deserialised library symbols.

Result: an aspect-only module compiled, but the IR weaver in any consumer module's compile saw zero aspects and bailed early.

## Discovery channel

Single channel: a marker file published by the producer, scanned by the consumer's **compiler plugin** itself (not by the Gradle plugin).

**Producer side**:
- Gradle plugin sets the `aspectIndexFile` subplugin option to `<buildDir>/aspectk/aspectIndex/<compilationName>/META-INF/aspectk/aspects.txt`.
- `AspectKIrGenerationExtension` writes the list of locally-discovered `` `@Aspect` `` FQNs to that file (one per line) when at least one is present.
- The Gradle plugin's `wireAspectIndexIntoJar` configures every Jar task to `from(...)` each `main`-flavoured compilation's index subdirectory; the JAR ends up with `META-INF/aspectk/aspects.txt` at the canonical location, no path rewriting needed.

**Consumer side**:
- `AspectKCompilerPluginRegistrar` reads `CLIConfigurationKeys.CONTENT_ROOTS` from `CompilerConfiguration`, filters for `JvmClasspathRoot` entries (skipping SDK roots), and snapshots the resulting `List<File>`. It passes that list into `AspectKIrGenerationExtension`'s constructor.
- The IR extension walks each classpath entry looking for the `META-INF/aspectk/aspects.txt` marker — both packaged JARs and exploded class directories are handled, so project dependencies that Gradle resolves to classes-dirs also work.
- Each discovered FQN is resolved to an `IrClassSymbol` through `pluginContext.finderForBuiltins().findClass(ClassId.topLevel(FqName(...)))` (per the `ir-plugincontext-usage` skill).
- The resulting `IrClass`es flow through `AspectAnalyzer.buildAspectMetadata` (newly exposed) — same IR-shape annotation reading whether the class came from source or a deserialised dependency.
- External `AspectMetadata` concatenates onto local `AspectMetadata` before handing the combined list to `AspectKTransformer`. Local weaving paths are unchanged.

## Why one channel, not two

An earlier draft of this PR split discovery across the Gradle plugin (which scanned classpath JARs) and an `externalAspects` subplugin option carrying the FQN list to the compiler plugin. That's redundant: the compiler plugin already sees the JVM classpath via `CompilerConfiguration`, so the Gradle-side scan adds no information and doubles the maintenance surface. The current PR keeps only the **producer-side `aspectIndexFile` option** and scans inside the compiler plugin; the bonus is that non-Gradle build tools (raw `kotlinc -Xplugin=`) get cross-module discovery for free as long as the marker JAR is on the compile classpath.

## Resolves PR #37's documented limitation

PR #37's `strictUnusedAspects` KDoc carried a "known limitation: cross-module aspect declaration isn't woven" note. This PR removes that note from both `AspectKAggregateReportTask.kt`'s `collectUnused` KDoc and `AspectKExtension.kt`'s `strictUnusedAspects` KDoc — the cross-module case now works correctly.

## Test plan

- [x] `./gradlew :aspectk-compiler:test :aspectk-gradle-plugin:test --rerun-tasks` green locally.
- [x] New TestKit case `aspect declared in dependency module weaves into consumer module call sites`:
   1. Two-module synthetic project: `:aspect` declares `@Aspect class GreetingTracer { @Before @MethodName("greet") fun beforeGreet() }`, `:consumer` depends on `:aspect` and defines `Greeter.greet(...)`.
   2. Runs `:consumer:run`.
   3. Asserts `ADVICE_BEFORE` appears before `hello world` — the only way that line gets printed is if the producer's index landed in the JAR, the consumer's compiler-plugin classpath scan discovered it, the IR finder resolved the external symbol, and the IR weaver wrapped the consumer's call site.
- [x] Existing single-module tests still green (`before advice weaves into a JVM target`, `aspectKAggregateReport collects per-module reports`, `aspectKAggregateReport in strict mode fails the build when an advice is unused`).
- [ ] CI on `feat/v1` green after rebase.

## Follow-up

- KMP targets beyond JVM JAR aren't exercised here. The `wireAspectIndexIntoJar` matches any `Jar` task but only surfaces `main` / `*Main` compilation indexes. JS / Native cases are future work.
- Nested aspect classes (`Foo.Inner`) aren't resolved by `ClassId.topLevel(...)` — top-level aspects only for now.
